### PR TITLE
Refactor style and format code

### DIFF
--- a/src/factsynth_ultimate/__init__.py
+++ b/src/factsynth_ultimate/__init__.py
@@ -1,2 +1,3 @@
 from .generator import generate_insight, FSUInput, FSUConfig
-__all__=['generate_insight','FSUInput','FSUConfig']
+
+__all__ = ["generate_insight", "FSUInput", "FSUConfig"]

--- a/src/factsynth_ultimate/api.py
+++ b/src/factsynth_ultimate/api.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
-import time, logging, orjson, json
-from fastapi import FastAPI, Depends, Request
-from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+import time
+import logging
+
+import orjson
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from pydantic import BaseModel, ValidationError
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from pydantic import BaseModel, ValidationError
 
-from .generator import FSUInput, FSUConfig, generate_insight
+from .generator import FSUConfig, FSUInput, generate_insight
 from .metrics import j_index
-from .settings import Settings
-from .security import api_key_auth, rate_limiter
 from .middleware import BodySizeLimitMiddleware
+from .orchestrator.pipeline import Orchestrator, ProjectSpec
 from .orchestrator.roles import RoleConfig
-from .orchestrator.pipeline import ProjectSpec, Orchestrator
+from .security import api_key_auth, rate_limiter
+from .settings import Settings
 
 app = FastAPI(title="FactSynth Ultimate API", version="2.0.0")
 CFG = FSUConfig()
@@ -21,56 +24,136 @@ S = Settings()
 
 app.add_middleware(GZipMiddleware, minimum_size=1024)
 app.add_middleware(BodySizeLimitMiddleware, max_content_length=S.MAX_BODY_BYTES)
-app.add_middleware(CORSMiddleware, allow_origins=S.CORS_ALLOW_ORIGINS, allow_methods=["POST","GET","OPTIONS"], allow_headers=["*"])
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=S.CORS_ALLOW_ORIGINS,
+    allow_methods=["POST", "GET", "OPTIONS"],
+    allow_headers=["*"],
+)
 
 logging.basicConfig(level=getattr(logging, S.LOG_LEVEL.upper(), logging.INFO))
 logger = logging.getLogger("fsu")
 
-class InsightResponse(BaseModel): text: str
-class ScoreResponse(BaseModel): text: str; F: float; R: float; D: float; A: float; N: float; J: float
-class GLRequest(BaseModel):
-    title: str; thesis: str; rounds: int = 2; roles: list[RoleConfig]
-class GLResponse(BaseModel):
-    markdown: str; html: str; metrics: dict
 
-@app.post("/v1/insight", response_model=InsightResponse, dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
+class InsightResponse(BaseModel):
+    text: str
+
+
+class ScoreResponse(BaseModel):
+    text: str
+    F: float
+    R: float
+    D: float
+    A: float
+    N: float
+    J: float
+
+
+class GLRequest(BaseModel):
+    title: str
+    thesis: str
+    rounds: int = 2
+    roles: list[RoleConfig]
+
+
+class GLResponse(BaseModel):
+    markdown: str
+    html: str
+    metrics: dict
+
+
+@app.post(
+    "/v1/insight",
+    response_model=InsightResponse,
+    dependencies=[Depends(api_key_auth), Depends(rate_limiter)],
+)
 def insight(inp: FSUInput) -> InsightResponse:
-    t0 = time.time(); out = generate_insight(inp, CFG)
-    logger.info(orjson.dumps({"route":"insight","ms":int((time.time()-t0)*1000)}).decode())
+    t0 = time.time()
+    out = generate_insight(inp, CFG)
+    logger.info(
+        orjson.dumps(
+            {"route": "insight", "ms": int((time.time() - t0) * 1000)}
+        ).decode()
+    )
     return InsightResponse(text=out)
 
-@app.post("/v1/intent_reflector", response_model=InsightResponse, dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
+
+@app.post(
+    "/v1/intent_reflector",
+    response_model=InsightResponse,
+    dependencies=[Depends(api_key_auth), Depends(rate_limiter)],
+)
 def intent_reflector(inp: FSUInput) -> InsightResponse:
-    data = inp.model_dump(); data["length"] = data.get("length") or CFG.length
+    data = inp.model_dump()
+    data["length"] = data.get("length") or CFG.length
     return InsightResponse(text=generate_insight(FSUInput(**data), CFG))
 
-@app.post("/v1/score", response_model=ScoreResponse, dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
+
+@app.post(
+    "/v1/score",
+    response_model=ScoreResponse,
+    dependencies=[Depends(api_key_auth), Depends(rate_limiter)],
+)
 def score(inp: FSUInput) -> ScoreResponse:
-    txt = generate_insight(inp, CFG); s = j_index(inp.intent, txt, CFG.start_phrase, facts=inp.facts, knowledge=inp.knowledge)
+    txt = generate_insight(inp, CFG)
+    s = j_index(
+        inp.intent,
+        txt,
+        CFG.start_phrase,
+        facts=inp.facts,
+        knowledge=inp.knowledge,
+    )
     return ScoreResponse(text=txt, **s)
+
 
 @app.post("/v1/stream", dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
 async def stream(inp: FSUInput):
     txt = generate_insight(inp, CFG)
-    async def it(): yield f"data: {txt}\n\n"
+
+    async def it():
+        yield f"data: {txt}\n\n"
+
     return StreamingResponse(it(), media_type="text/event-stream")
 
-@app.post("/v1/glrtpm/run", response_model=GLResponse, dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
+
+@app.post(
+    "/v1/glrtpm/run",
+    response_model=GLResponse,
+    dependencies=[Depends(api_key_auth), Depends(rate_limiter)],
+)
 def glrtpm_run(req: GLRequest) -> GLResponse:
-    spec = ProjectSpec(title=req.title, thesis=req.thesis, roles=req.roles, rounds=req.rounds)
-    orch = Orchestrator(spec); res = orch.run()
-    return GLResponse(markdown=res["markdown"], html=res["html"], metrics=res["metrics"])
+    spec = ProjectSpec(
+        title=req.title,
+        thesis=req.thesis,
+        roles=req.roles,
+        rounds=req.rounds,
+    )
+    orch = Orchestrator(spec)
+    res = orch.run()
+    return GLResponse(
+        markdown=res["markdown"], html=res["html"], metrics=res["metrics"]
+    )
+
 
 @app.get("/v1/healthz")
-def healthz(): return {"status":"ok","version":app.version}
+def healthz():
+    return {"status": "ok", "version": app.version}
+
 
 @app.get("/metrics")
-def metrics(): return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+def metrics():
+    return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
 
 @app.exception_handler(ValidationError)
 async def verror(_: Request, exc: ValidationError):
-    return JSONResponse(status_code=422, content={"error":"validation_error","detail":exc.errors()})
+    return JSONResponse(
+        status_code=422,
+        content={"error": "validation_error", "detail": exc.errors()},
+    )
+
 
 def run():
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/factsynth_ultimate/cli.py
+++ b/src/factsynth_ultimate/cli.py
@@ -1,4 +1,7 @@
-import json, typer, yaml, os
+import json
+import typer
+import yaml
+import os
 from .generator import FSUInput, FSUConfig, generate_insight
 from .metrics import j_index
 from .orchestrator.roles import RoleConfig
@@ -6,27 +9,44 @@ from .orchestrator.pipeline import ProjectSpec, Orchestrator
 
 app = typer.Typer(help="FactSynth Ultimate CLI")
 
+
 @app.command()
 def insight(intent: str, length: int = 100):
     print(generate_insight(FSUInput(intent=intent, length=length), FSUConfig()))
 
-@app.command()
-def score(intent: str, length: int = 100):
-    cfg = FSUConfig(); txt = generate_insight(FSUInput(intent=intent, length=length), cfg)
-    print(txt, "\n---\n", j_index(intent, txt, cfg.start_phrase))
 
 @app.command()
-def glrtpm(spec: str = typer.Argument(..., help="YAML конфіг GLRTPM"), outdir: str = "./dist"):
+def score(intent: str, length: int = 100):
+    cfg = FSUConfig()
+    txt = generate_insight(FSUInput(intent=intent, length=length), cfg)
+    print(txt, "\n---\n", j_index(intent, txt, cfg.start_phrase))
+
+
+@app.command()
+def glrtpm(
+    spec: str = typer.Argument(..., help="YAML конфіг GLRTPM"), outdir: str = "./dist"
+):
     os.makedirs(outdir, exist_ok=True)
     cfg = yaml.safe_load(open(spec, "r", encoding="utf-8"))
     roles = [RoleConfig(**r) for r in cfg["roles"]]
-    ps = ProjectSpec(title=cfg["title"], thesis=cfg["thesis"], roles=roles, rounds=cfg.get("rounds",2))
-    orch = Orchestrator(ps); res = orch.run()
+    ps = ProjectSpec(
+        title=cfg["title"],
+        thesis=cfg["thesis"],
+        roles=roles,
+        rounds=cfg.get("rounds", 2),
+    )
+    orch = Orchestrator(ps)
+    res = orch.run()
     base = os.path.join(outdir, "tractate")
-    open(base+".md","w",encoding="utf-8").write(res["markdown"])
-    open(base+".html","w",encoding="utf-8").write(res["html"])
-    open(base+".metrics.json","w",encoding="utf-8").write(json.dumps(res["metrics"], ensure_ascii=False, indent=2))
+    open(base + ".md", "w", encoding="utf-8").write(res["markdown"])
+    open(base + ".html", "w", encoding="utf-8").write(res["html"])
+    open(
+        base + ".metrics.json",
+        "w",
+        encoding="utf-8",
+    ).write(json.dumps(res["metrics"], ensure_ascii=False, indent=2))
     print("OK →", outdir)
+
 
 if __name__ == "__main__":
     app()

--- a/src/factsynth_ultimate/config.py
+++ b/src/factsynth_ultimate/config.py
@@ -1,4 +1,6 @@
 from pydantic import BaseModel
+
+
 class FSUConfig(BaseModel):
     language: str = "uk"
     length: int = 100

--- a/src/factsynth_ultimate/formatting.py
+++ b/src/factsynth_ultimate/formatting.py
@@ -1,28 +1,64 @@
 from __future__ import annotations
 import regex as re
-from .tokenization import tokenize, normalize, count_words
+from .tokenization import tokenize, normalize
+
 EMOJI_RANGE = (0x1F300, 0x1FAFF)
 HEAD_PAT = re.compile(r"^\s*(#+|={3,}|-{3,})", re.M)
 LIST_PAT = re.compile(r"^\s*([\-*•·]|\d+\.)\s+", re.M)
 SPACE_PAT = re.compile(r"\s+")
-def has_emoji(s: str) -> bool: return any(EMOJI_RANGE[0] <= ord(ch) <= EMOJI_RANGE[1] for ch in s)
-def sanitize(text: str, *, forbid_questions=True, forbid_headings=True, forbid_lists=True, forbid_emojis=True) -> str:
+
+
+def has_emoji(s: str) -> bool:
+    return any(EMOJI_RANGE[0] <= ord(ch) <= EMOJI_RANGE[1] for ch in s)
+
+
+def sanitize(
+    text: str,
+    *,
+    forbid_questions=True,
+    forbid_headings=True,
+    forbid_lists=True,
+    forbid_emojis=True,
+) -> str:
     t = normalize(text)
-    if forbid_questions: t = t.replace("?", ".")
+    if forbid_questions:
+        t = t.replace("?", ".")
     t = SPACE_PAT.sub(" ", t).strip()
-    if forbid_headings and HEAD_PAT.search(t): t = HEAD_PAT.sub("", t)
-    if forbid_lists and LIST_PAT.search(t): t = LIST_PAT.sub("", t)
-    if forbid_emojis and has_emoji(t): t = re.sub(r"[\p{Emoji_Presentation}]", "", t)
+    if forbid_headings and HEAD_PAT.search(t):
+        t = HEAD_PAT.sub("", t)
+    if forbid_lists and LIST_PAT.search(t):
+        t = LIST_PAT.sub("", t)
+    if forbid_emojis and has_emoji(t):
+        t = re.sub(r"[\p{Emoji_Presentation}]", "", t)
     return t
-def ensure_period(text: str) -> str: t = text.rstrip(); return t if t.endswith(('.', '…')) else (t + ".")
+
+
+def ensure_period(text: str) -> str:
+    t = text.rstrip()
+    return t if t.endswith((".", "…")) else (t + ".")
+
+
 def fit_length(text: str, target: int) -> str:
     words = tokenize(text)
-    if len(words) == target: return ensure_period(text)
+    if len(words) == target:
+        return ensure_period(text)
     if len(words) > target:
-        removable = {"дуже","саме","реально","зайве","надмірно","дещо","украй"}
+        removable = {
+            "дуже",
+            "саме",
+            "реально",
+            "зайве",
+            "надмірно",
+            "дещо",
+            "украй",
+        }
         filtered = [w for w in words if w.lower() not in removable]
         words = filtered if len(filtered) >= target else words
-        words = words[:target]; return ensure_period(" ".join(words))
-    pad = ["Дію","послідовно","і","зважено."]; i = 0
-    while len(words) < target: words.append(pad[i % len(pad)]); i += 1
+        words = words[:target]
+        return ensure_period(" ".join(words))
+    pad = ["Дію", "послідовно", "і", "зважено."]
+    i = 0
+    while len(words) < target:
+        words.append(pad[i % len(pad)])
+        i += 1
     return ensure_period(" ".join(words))

--- a/src/factsynth_ultimate/generator.py
+++ b/src/factsynth_ultimate/generator.py
@@ -4,7 +4,8 @@ from .formatting import sanitize, fit_length
 from .tokenization import count_words
 from .config import FSUConfig
 
-VALENCE = {"досягнення","контроль","зв’язок","безпека","визнання","новизна"}
+VALENCE = {"досягнення", "контроль", "зв’язок", "безпека", "визнання", "новизна"}
+
 
 class FSUInput(BaseModel):
     intent: str = Field(..., description="Явний намір")
@@ -22,45 +23,58 @@ class FSUInput(BaseModel):
     @field_validator("length")
     @classmethod
     def v_len(cls, v):
-        if v is not None and v <= 0: raise ValueError("length must be > 0")
+        if v is not None and v <= 0:
+            raise ValueError("length must be > 0")
         return v
+
     @field_validator("valence")
     @classmethod
     def v_val(cls, v):
-        if v is None: return v
-        if v not in VALENCE: raise ValueError("invalid valence")
+        if v is None:
+            return v
+        if v not in VALENCE:
+            raise ValueError("invalid valence")
         return v
+
 
 def _infer_valence(text: str) -> str:
     t = text.lower()
-    if any(k in t for k in ["нове","інновац","експерим"]): return "новизна"
-    if any(k in t for k in ["визнан","репутац","оцінк"]): return "визнання"
-    if any(k in t for k in ["безпек","ризик"]): return "безпека"
-    if any(k in t for k in ["контрол","керуван"]): return "контроль"
-    if any(k in t for k in ["команд","спільнот","зв’яз","віднос"]): return "зв’язок"
+    if any(k in t for k in ["нове", "інновац", "експерим"]):
+        return "новизна"
+    if any(k in t for k in ["визнан", "репутац", "оцінк"]):
+        return "визнання"
+    if any(k in t for k in ["безпек", "ризик"]):
+        return "безпека"
+    if any(k in t for k in ["контрол", "керуван"]):
+        return "контроль"
+    if any(k in t for k in ["команд", "спільнот", "зв’яз", "віднос"]):
+        return "зв’язок"
     return "досягнення"
+
 
 def generate_insight(inp: FSUInput, cfg: FSUConfig = FSUConfig()) -> str:
     L = inp.length or cfg.length
     v = inp.valence if inp.valence in VALENCE else _infer_valence(inp.intent)
     motive = inp.motive or "конкретизація і перевірка корисності"
-    constraints = inp.constraints or "обмежені когнітивні ресурси та семантична чіткість"
+    constraints = (
+        inp.constraints or "обмежені когнітивні ресурси та семантична чіткість"
+    )
     blocker = inp.blocker or "нейронний шум і втрата контексту"
     horizon = inp.horizon or "ітеративний"
     metric = inp.metric or "релевантність/глибина/застосовність"
     default_action = inp.default_action or "контекстна емпатія/аналіз"
 
     parts = [
-      f"{cfg.start_phrase} точного віддзеркалення наміру, щоб перетворити його на керований KPI префронтальної кори.",
-      f"Прихована мета — {v}, бо потрібна {motive}.",
-      f"Головним обмеженням виступають {constraints}.",
-      f"Ключовий блокер — {blocker}.",
-      "Вирішальною дією стане активація асоціативних шляхів через стислий семантичний синтез.",
-      f"Успіх вимірюється через {metric}.",
-      f"Часовий горизонт — {horizon}.",
-      "Ризик перевантаження знімаємо модульним спрощенням і чіткими межами контексту.",
-      f"Дія за замовчуванням — {default_action}.",
-      "Я синхронізуюсь із твоїми інтенціями та тримаю операційну дисципліну."
+        f"{cfg.start_phrase} точного віддзеркалення наміру, щоб перетворити його на керований KPI префронтальної кори.",
+        f"Прихована мета — {v}, бо потрібна {motive}.",
+        f"Головним обмеженням виступають {constraints}.",
+        f"Ключовий блокер — {blocker}.",
+        "Вирішальною дією стане активація асоціативних шляхів через стислий семантичний синтез.",
+        f"Успіх вимірюється через {metric}.",
+        f"Часовий горизонт — {horizon}.",
+        "Ризик перевантаження знімаємо модульним спрощенням і чіткими межами контексту.",
+        f"Дія за замовчуванням — {default_action}.",
+        "Я синхронізуюсь із твоїми інтенціями та тримаю операційну дисципліну.",
     ]
 
     seeds = []
@@ -75,11 +89,13 @@ def generate_insight(inp: FSUInput, cfg: FSUConfig = FSUConfig()) -> str:
     if not inp.motive or not inp.constraints:
         text += f" [Assumption: {cfg.fallback_assumption}]"
 
-    text = sanitize(text,
-                    forbid_questions=cfg.forbid_questions,
-                    forbid_headings=cfg.forbid_headings,
-                    forbid_lists=cfg.forbid_lists,
-                    forbid_emojis=cfg.forbid_emojis)
+    text = sanitize(
+        text,
+        forbid_questions=cfg.forbid_questions,
+        forbid_headings=cfg.forbid_headings,
+        forbid_lists=cfg.forbid_lists,
+        forbid_emojis=cfg.forbid_emojis,
+    )
     text = fit_length(text, L)
     assert count_words(text) == L, f"length mismatch: {count_words(text)} != {L}"
     assert text.startswith(cfg.start_phrase), "must start with start_phrase"

--- a/src/factsynth_ultimate/metrics.py
+++ b/src/factsynth_ultimate/metrics.py
@@ -3,42 +3,85 @@ from dataclasses import dataclass
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
-ACTION_VERBS = ["запустити","калібрувати","визначити","перевірити","впровадити","виміряти","спростити","скласти","застосувати"]
+ACTION_VERBS = [
+    "запустити",
+    "калібрувати",
+    "визначити",
+    "перевірити",
+    "впровадити",
+    "виміряти",
+    "спростити",
+    "скласти",
+    "застосувати",
+]
+
 
 def relevance_cosine(intent: str, text: str) -> float:
-    vec = TfidfVectorizer(min_df=1, ngram_range=(1,2))
+    vec = TfidfVectorizer(min_df=1, ngram_range=(1, 2))
     X = vec.fit_transform([intent, text])
-    return float(cosine_similarity(X[0], X[1])[0,0])
+    return float(cosine_similarity(X[0], X[1])[0, 0])
+
 
 def depth_score(text: str) -> float:
-    cues = ["метрика","обмеженн","блокер","горизонт","асоціатив","ризик","дія за замовчуванням"]
+    cues = [
+        "метрика",
+        "обмеженн",
+        "блокер",
+        "горизонт",
+        "асоціатив",
+        "ризик",
+        "дія за замовчуванням",
+    ]
     hit = sum(c in text.lower() for c in cues)
-    return min(1.0, hit/7.0)
+    return min(1.0, hit / 7.0)
+
 
 def applicability_score(text: str) -> float:
     hit = sum(v in text.lower() for v in ACTION_VERBS)
-    return min(1.0, hit/4.0)
+    return min(1.0, hit / 4.0)
+
 
 def novelty_score(base: list[str] | None, text: str) -> float:
-    if not base: return 0.5
+    if not base:
+        return 0.5
     src = " ".join(base).lower().split()
-    if not src: return 0.5
+    if not src:
+        return 0.5
     out = set(text.lower().split())
     overlap = len([w for w in out if w in src]) / max(1, len(out))
     return max(0.0, min(1.0, 1.0 - overlap))
 
+
 def format_ok(text: str, start_phrase: str) -> float:
     return 1.0 if (text.startswith(start_phrase) and "?" not in text) else 0.0
 
+
 @dataclass
 class JWeights:
-    wF: float = 0.20; wR: float = 0.30; wD: float = 0.25; wA: float = 0.15; wN: float = 0.10
+    wF: float = 0.20
+    wR: float = 0.30
+    wD: float = 0.25
+    wA: float = 0.15
+    wN: float = 0.10
 
-def j_index(intent: str, text: str, start_phrase: str, facts: list[str] | None = None, knowledge: list[str] | None = None) -> dict:
+
+def j_index(
+    intent: str,
+    text: str,
+    start_phrase: str,
+    facts: list[str] | None = None,
+    knowledge: list[str] | None = None,
+) -> dict:
     F = format_ok(text, start_phrase)
     R = relevance_cosine(intent, text)
     D = depth_score(text)
     A = applicability_score(text)
     N = novelty_score((facts or []) + (knowledge or []), text)
-    J = JWeights().wF*F + JWeights().wR*R + JWeights().wD*D + JWeights().wA*A + JWeights().wN*N
-    return {"F":F, "R":R, "D":D, "A":A, "N":N, "J":J}
+    J = (
+        JWeights().wF * F
+        + JWeights().wR * R
+        + JWeights().wD * D
+        + JWeights().wA * A
+        + JWeights().wN * N
+    )
+    return {"F": F, "R": R, "D": D, "A": A, "N": N, "J": J}

--- a/src/factsynth_ultimate/middleware.py
+++ b/src/factsynth_ultimate/middleware.py
@@ -1,9 +1,13 @@
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
 class BodySizeLimitMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, max_content_length: int = 256_000):
-        super().__init__(app); self.max = max_content_length
+        super().__init__(app)
+        self.max = max_content_length
+
     async def dispatch(self, request: Request, call_next):
         cl = request.headers.get("content-length")
         if cl and cl.isdigit() and int(cl) > self.max:

--- a/src/factsynth_ultimate/orchestrator/exporter.py
+++ b/src/factsynth_ultimate/orchestrator/exporter.py
@@ -1,8 +1,13 @@
 from typing import List
 import markdown
+
+
 def to_markdown(title: str, sections: List[tuple]) -> str:
     md = [f"# {title}\n"]
-    for h, body in sections: md.append(f"## {h}\n\n{body}\n")
+    for h, body in sections:
+        md.append(f"## {h}\n\n{body}\n")
     return "\n".join(md)
+
+
 def to_html(md_text: str) -> str:
     return markdown.markdown(md_text, extensions=["fenced_code", "tables"])

--- a/src/factsynth_ultimate/orchestrator/llm_offline.py
+++ b/src/factsynth_ultimate/orchestrator/llm_offline.py
@@ -1,14 +1,20 @@
 from typing import Optional
 import random
 
+
 class OfflineLLM:
     """Детермінований офлайн-генератор: стилізована трансформація, без мережі."""
+
     def __init__(self, seed: int = 7):
         random.seed(seed)
 
-    def generate(self, prompt: str, system: Optional[str] = None, temperature: float = 0.2) -> str:
-        lines = [l.strip() for l in prompt.splitlines() if l.strip()]
+    def generate(
+        self, prompt: str, system: Optional[str] = None, temperature: float = 0.2
+    ) -> str:
+        lines = [line.strip() for line in prompt.splitlines() if line.strip()]
         head = lines[:2]
         body = " ".join(lines[2:])[:1200]
-        tags = ", ".join(sorted(set([w.lower() for w in body.split() if len(w) > 7]))[:6])
+        tags = ", ".join(
+            sorted(set([w.lower() for w in body.split() if len(w) > 7]))[:6]
+        )
         return f"{' '.join(head)}\n\n{body}\n\n[offline-synth • temp={temperature} • tags: {tags}]"

--- a/src/factsynth_ultimate/orchestrator/memory.py
+++ b/src/factsynth_ultimate/orchestrator/memory.py
@@ -2,15 +2,21 @@ from typing import List, Tuple
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
+
 class VectorMemory:
     def __init__(self):
         self.docs: List[str] = []
         self.vec = TfidfVectorizer()
         self.matrix = None
+
     def add(self, text: str):
-        self.docs.append(text); self.matrix = self.vec.fit_transform(self.docs)
+        self.docs.append(text)
+        self.matrix = self.vec.fit_transform(self.docs)
+
     def search(self, query: str, topk: int = 3) -> List[Tuple[int, float, str]]:
-        if not self.docs: return []
-        q = self.vec.transform([query]); sims = cosine_similarity(q, self.matrix).ravel()
+        if not self.docs:
+            return []
+        q = self.vec.transform([query])
+        sims = cosine_similarity(q, self.matrix).ravel()
         idx = sims.argsort()[::-1][:topk]
         return [(int(i), float(sims[i]), self.docs[i]) for i in idx]

--- a/src/factsynth_ultimate/orchestrator/metrics_glrtpm.py
+++ b/src/factsynth_ultimate/orchestrator/metrics_glrtpm.py
@@ -1,23 +1,39 @@
-from typing import List, Dict
+from typing import Dict, List
+
+import numpy as np
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
-import numpy as np
+
 
 def coherence(docs: List[str]) -> float:
-    if len(docs) < 2: return 1.0
-    vec = TfidfVectorizer(); X = vec.fit_transform(docs); S = cosine_similarity(X)
-    n = S.shape[0]; return float((S.sum() - n) / (n*(n-1)))
+    if len(docs) < 2:
+        return 1.0
+    vec = TfidfVectorizer()
+    X = vec.fit_transform(docs)
+    S = cosine_similarity(X)
+    n = S.shape[0]
+    return float((S.sum() - n) / (n * (n - 1)))
+
 
 def diversity(docs: List[str]) -> float:
-    if len(docs) < 2: return 0.0
-    vec = TfidfVectorizer(); X = vec.fit_transform(docs); S = cosine_similarity(X)
+    if len(docs) < 2:
+        return 0.0
+    vec = TfidfVectorizer()
+    X = vec.fit_transform(docs)
+    S = cosine_similarity(X)
     return float(1.0 - S[np.triu_indices(S.shape[0], k=1)].mean())
 
+
 def contradiction_rate(thesis_blocks: List[str], counter_blocks: List[str]) -> float:
-    if not thesis_blocks or not counter_blocks: return 0.0
-    vec = TfidfVectorizer(); X = vec.fit_transform(thesis_blocks + counter_blocks); n = len(thesis_blocks)
-    A, B = X[:n], X[n:]; S = cosine_similarity(A, B).mean()
+    if not thesis_blocks or not counter_blocks:
+        return 0.0
+    vec = TfidfVectorizer()
+    X = vec.fit_transform(thesis_blocks + counter_blocks)
+    n = len(thesis_blocks)
+    A, B = X[:n], X[n:]
+    S = cosine_similarity(A, B).mean()
     return float(1.0 - S)
+
 
 def acceptance(coh: float, div: float, contra: float) -> Dict[str, float]:
     return {"coherence": coh, "diversity": div, "contradiction": contra}

--- a/src/factsynth_ultimate/orchestrator/pipeline.py
+++ b/src/factsynth_ultimate/orchestrator/pipeline.py
@@ -6,12 +6,14 @@ from .memory import VectorMemory
 from .metrics_glrtpm import coherence, diversity, contradiction_rate, acceptance
 from .exporter import to_markdown, to_html
 
+
 @dataclass
 class ProjectSpec:
     title: str
     thesis: str
     roles: List[RoleConfig]
     rounds: int = 2
+
 
 class Orchestrator:
     def __init__(self, spec: ProjectSpec):
@@ -21,7 +23,9 @@ class Orchestrator:
         self.llm = OfflineLLM()
 
     def _gen(self, system: str, prompt: str, temp: float = 0.2) -> str:
-        return self.llm.generate(prompt=system + "\n\n" + prompt, system=system, temperature=temp)
+        return self.llm.generate(
+            prompt=system + "\n\n" + prompt, system=system, temperature=temp
+        )
 
     def run(self) -> Dict[str, Any]:
         thesis_blocks, counter_blocks, role_outputs = [], [], []
@@ -29,20 +33,37 @@ class Orchestrator:
             sys = r.instruct()
             t = self._gen(sys, f"Сформуй тезу за темою: {self.spec.thesis}")
             c = self._gen(sys, f"Сформуй контртезу до: {self.spec.thesis}")
-            s = self._gen(sys, f"Стислий висновок з критеріями валідації для читача.")
-            block = r.format(thesis=t, support="Аргументи й приклади (синтез).", counter=c, summary=s)
+            s = self._gen(sys, "Стислий висновок з критеріями валідації для читача.")
+            block = r.format(
+                thesis=t,
+                support="Аргументи й приклади (синтез).",
+                counter=c,
+                summary=s,
+            )
             self.vm.add(block)
-            thesis_blocks.append(t); counter_blocks.append(c); role_outputs.append((r.cfg.name, block))
+            thesis_blocks.append(t)
+            counter_blocks.append(c)
+            role_outputs.append((r.cfg.name, block))
 
         coh = coherence([b for _, b in role_outputs])
         div = diversity([b for _, b in role_outputs])
         contra = contradiction_rate(thesis_blocks, counter_blocks)
         acc = acceptance(coh, div, contra)
 
-        integr = self._gen("Інтегратор", "Синтезуй єдину позицію з урахуванням тез і контртез.")
+        integr = self._gen(
+            "Інтегратор",
+            "Синтезуй єдину позицію з урахуванням тез і контртез.",
+        )
         sections = [("Маніфест", integr)]
-        for name, block in role_outputs: sections.append((f"Роль: {name}", block))
-        sections.append(("Метрики", f"- Coherence: {coh:.3f}\n- Diversity: {div:.3f}\n- Contradiction: {contra:.3f}"))
+        for name, block in role_outputs:
+            sections.append((f"Роль: {name}", block))
+        sections.append(
+            (
+                "Метрики",
+                f"- Coherence: {coh:.3f}\n- Diversity: {div:.3f}\n- Contradiction: {contra:.3f}",
+            )
+        )
 
-        md = to_markdown(self.spec.title, sections); html = to_html(md)
+        md = to_markdown(self.spec.title, sections)
+        html = to_html(md)
         return {"markdown": md, "html": html, "metrics": acc, "sections": sections}

--- a/src/factsynth_ultimate/orchestrator/roles.py
+++ b/src/factsynth_ultimate/orchestrator/roles.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
+
 @dataclass
 class RoleConfig:
     name: str
@@ -8,15 +9,19 @@ class RoleConfig:
     style: str
     heuristics: List[str]
 
-DEFAULT_CANON = (
-    "ТЕЗА:\n{thesis}\n\nОБҐРУНТУВАННЯ:\n{support}\n\nКОНТРТЕЗА:\n{counter}\n\nРЕЗЮМЕ:\n{summary}"
-)
+
+DEFAULT_CANON = "ТЕЗА:\n{thesis}\n\nОБҐРУНТУВАННЯ:\n{support}\n\nКОНТРТЕЗА:\n{counter}\n\nРЕЗЮМЕ:\n{summary}"
+
 
 @dataclass
 class Role:
     cfg: RoleConfig
+
     def format(self, thesis: str, support: str, counter: str, summary: str) -> str:
-        return DEFAULT_CANON.format(thesis=thesis, support=support, counter=counter, summary=summary)
+        return DEFAULT_CANON.format(
+            thesis=thesis, support=support, counter=counter, summary=summary
+        )
+
     def instruct(self) -> str:
         h = ", ".join(self.cfg.heuristics) if self.cfg.heuristics else "—"
         return f"[{self.cfg.name}] Мета: {self.cfg.goal}. Стиль: {self.cfg.style}. Евристики: {h}."

--- a/src/factsynth_ultimate/security.py
+++ b/src/factsynth_ultimate/security.py
@@ -1,26 +1,40 @@
 from time import time
 from fastapi import Header, HTTPException
+
 try:
     import jwt
 except Exception:
     jwt = None
 from .settings import Settings
+
 S = Settings()
 _BUCKET = {}
 
-async def api_key_auth(x_api_key: str | None = Header(None), authorization: str | None = Header(None)):
+
+async def api_key_auth(
+    x_api_key: str | None = Header(None),
+    authorization: str | None = Header(None),
+):
     if S.API_KEY and x_api_key == S.API_KEY:
         return
-    if authorization and authorization.startswith("Bearer ") and S.JWT_PUBLIC_KEY and jwt:
-        token = authorization.split(" ",1)[1]
+    if (
+        authorization
+        and authorization.startswith("Bearer ")
+        and S.JWT_PUBLIC_KEY
+        and jwt
+    ):
+        token = authorization.split(" ", 1)[1]
         try:
             payload = jwt.decode(token, S.JWT_PUBLIC_KEY, algorithms=[S.JWT_ALG])
-            if S.JWT_REQUIRED_AUD and S.JWT_REQUIRED_AUD not in (payload.get("aud") or []):
+            if S.JWT_REQUIRED_AUD and S.JWT_REQUIRED_AUD not in (
+                payload.get("aud") or []
+            ):
                 raise HTTPException(status_code=403, detail="jwt_audience_mismatch")
             return
         except Exception:
             raise HTTPException(status_code=401, detail="invalid_jwt")
     raise HTTPException(status_code=401, detail="unauthorized")
+
 
 async def rate_limiter(x_api_key: str | None = Header(None)):
     key = x_api_key or "anon"
@@ -29,7 +43,8 @@ async def rate_limiter(x_api_key: str | None = Header(None)):
     tok, ts = _BUCKET.get(key, (cap, now))
     if now > ts:
         delta = now - ts
-        tok = min(cap, tok + (cap * delta // window)); ts = now
+        tok = min(cap, tok + (cap * delta // window))
+        ts = now
     if tok <= 0:
         raise HTTPException(status_code=429, detail="rate_limited")
     _BUCKET[key] = (tok - 1, ts)

--- a/src/factsynth_ultimate/settings.py
+++ b/src/factsynth_ultimate/settings.py
@@ -1,10 +1,12 @@
 from pydantic import BaseSettings
 from typing import List
+
+
 class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     API_KEY: str = "change-me"
     MAX_BODY_BYTES: int = 256_000
-    CORS_ALLOW_ORIGINS: List[str] = ["http://localhost:5173","http://127.0.0.1:5173"]
+    CORS_ALLOW_ORIGINS: List[str] = ["http://localhost:5173", "http://127.0.0.1:5173"]
     RATE_WINDOW_SEC: int = 10
     RATE_MAX_REQ: int = 60
     JWT_PUBLIC_KEY: str | None = None

--- a/src/factsynth_ultimate/tokenization.py
+++ b/src/factsynth_ultimate/tokenization.py
@@ -1,5 +1,17 @@
-import unicodedata, regex as re
+import unicodedata
+
+import regex as re
+
 _TOKEN_RE = re.compile(r"[\p{L}\p{N}ʼ'\-]+", re.UNICODE)
-def normalize(text: str) -> str: return unicodedata.normalize("NFC", text)
-def tokenize(text: str) -> list[str]: return _TOKEN_RE.findall(normalize(text))
-def count_words(text: str) -> int: return len(tokenize(text))
+
+
+def normalize(text: str) -> str:
+    return unicodedata.normalize("NFC", text)
+
+
+def tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(normalize(text))
+
+
+def count_words(text: str) -> int:
+    return len(tokenize(text))


### PR DESCRIPTION
## Summary
- expand compressed statements across API, formatting, orchestrator, and other modules
- split semicolon-delimited code and tidy imports
- run ruff formatting across `src/factsynth_ultimate`

## Testing
- `make lint` *(fails: .venv/bin/activate not found)*
- `ruff check src/factsynth_ultimate`


------
https://chatgpt.com/codex/tasks/task_e_68bc9f58c19483298ebf3fa7ed2656ae