### PR TITLE
refactor api tests to use fastapi TestClient

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,11 @@
-import threading, time, httpx
-from src.factsynth_ultimate.api import run
+from fastapi.testclient import TestClient
+from src.factsynth_ultimate.api import app
 
-def _spawn():
-    th = threading.Thread(target=run, daemon=True); th.start(); time.sleep(0.8)
 
 def test_endpoints_ok():
-    _spawn()
-    base = "http://127.0.0.1:8000"
-    H = {"x-api-key":"change-me","content-type":"application/json"}
-    r = httpx.get(base+"/v1/healthz")
-    assert r.status_code == 200
-    r2 = httpx.post(base+"/v1/intent_reflector", headers=H, json={"intent":"Тест","length":100})
-    assert r2.status_code == 200 and "text" in r2.json()
+    H = {"x-api-key": "change-me", "content-type": "application/json"}
+    with TestClient(app) as client:
+        r = client.get("/v1/healthz")
+        assert r.status_code == 200
+        r2 = client.post("/v1/intent_reflector", headers=H, json={"intent": "Тест", "length": 100})
+        assert r2.status_code == 200 and "text" in r2.json()


### PR DESCRIPTION
## Summary
- replace threaded server tests with FastAPI's TestClient for API endpoint checks

## Testing
- `PYTHONPATH=src pytest --override-ini addopts= -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68bc9f6147e4832981d9436fafb4c5e1