### PR TITLE
refactor: make FSU config and settings injectable

### DIFF
--- a/src/factsynth_ultimate/api.py
+++ b/src/factsynth_ultimate/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-import time, logging, orjson, json
+
+import time, logging, orjson
 from fastapi import FastAPI, Depends, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -10,67 +11,151 @@ from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from .generator import FSUInput, FSUConfig, generate_insight
 from .metrics import j_index
 from .settings import Settings
-from .security import api_key_auth, rate_limiter
+from .security import Security
 from .middleware import BodySizeLimitMiddleware
 from .orchestrator.roles import RoleConfig
 from .orchestrator.pipeline import ProjectSpec, Orchestrator
 
-app = FastAPI(title="FactSynth Ultimate API", version="2.0.0")
-CFG = FSUConfig()
-S = Settings()
 
-app.add_middleware(GZipMiddleware, minimum_size=1024)
-app.add_middleware(BodySizeLimitMiddleware, max_content_length=S.MAX_BODY_BYTES)
-app.add_middleware(CORSMiddleware, allow_origins=S.CORS_ALLOW_ORIGINS, allow_methods=["POST","GET","OPTIONS"], allow_headers=["*"])
+class InsightResponse(BaseModel):
+    text: str
 
-logging.basicConfig(level=getattr(logging, S.LOG_LEVEL.upper(), logging.INFO))
-logger = logging.getLogger("fsu")
 
-class InsightResponse(BaseModel): text: str
-class ScoreResponse(BaseModel): text: str; F: float; R: float; D: float; A: float; N: float; J: float
+class ScoreResponse(BaseModel):
+    text: str
+    F: float
+    R: float
+    D: float
+    A: float
+    N: float
+    J: float
+
+
 class GLRequest(BaseModel):
-    title: str; thesis: str; rounds: int = 2; roles: list[RoleConfig]
+    title: str
+    thesis: str
+    rounds: int = 2
+    roles: list[RoleConfig]
+
+
 class GLResponse(BaseModel):
-    markdown: str; html: str; metrics: dict
+    markdown: str
+    html: str
+    metrics: dict
 
-@app.post("/v1/insight", response_model=InsightResponse, dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
-def insight(inp: FSUInput) -> InsightResponse:
-    t0 = time.time(); out = generate_insight(inp, CFG)
-    logger.info(orjson.dumps({"route":"insight","ms":int((time.time()-t0)*1000)}).decode())
-    return InsightResponse(text=out)
 
-@app.post("/v1/intent_reflector", response_model=InsightResponse, dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
-def intent_reflector(inp: FSUInput) -> InsightResponse:
-    data = inp.model_dump(); data["length"] = data.get("length") or CFG.length
-    return InsightResponse(text=generate_insight(FSUInput(**data), CFG))
+def create_app(cfg: FSUConfig | None = None, settings: Settings | None = None) -> FastAPI:
+    cfg = cfg or FSUConfig()
+    settings = settings or Settings()
+    app = FastAPI(title="FactSynth Ultimate API", version="2.0.0")
+    app.state.cfg = cfg
+    app.state.settings = settings
 
-@app.post("/v1/score", response_model=ScoreResponse, dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
-def score(inp: FSUInput) -> ScoreResponse:
-    txt = generate_insight(inp, CFG); s = j_index(inp.intent, txt, CFG.start_phrase, facts=inp.facts, knowledge=inp.knowledge)
-    return ScoreResponse(text=txt, **s)
+    app.add_middleware(GZipMiddleware, minimum_size=1024)
+    app.add_middleware(BodySizeLimitMiddleware, max_content_length=settings.MAX_BODY_BYTES)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.CORS_ALLOW_ORIGINS,
+        allow_methods=["POST", "GET", "OPTIONS"],
+        allow_headers=["*"],
+    )
 
-@app.post("/v1/stream", dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
-async def stream(inp: FSUInput):
-    txt = generate_insight(inp, CFG)
-    async def it(): yield f"data: {txt}\n\n"
-    return StreamingResponse(it(), media_type="text/event-stream")
+    logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO))
+    logger = logging.getLogger("fsu")
+    security = Security(settings)
 
-@app.post("/v1/glrtpm/run", response_model=GLResponse, dependencies=[Depends(api_key_auth), Depends(rate_limiter)])
-def glrtpm_run(req: GLRequest) -> GLResponse:
-    spec = ProjectSpec(title=req.title, thesis=req.thesis, roles=req.roles, rounds=req.rounds)
-    orch = Orchestrator(spec); res = orch.run()
-    return GLResponse(markdown=res["markdown"], html=res["html"], metrics=res["metrics"])
+    @app.post(
+        "/v1/insight",
+        response_model=InsightResponse,
+        dependencies=[Depends(security.api_key_auth), Depends(security.rate_limiter)],
+    )
+    def insight(inp: FSUInput) -> InsightResponse:
+        t0 = time.time()
+        out = generate_insight(inp, cfg)
+        logger.info(
+            orjson.dumps({"route": "insight", "ms": int((time.time() - t0) * 1000)}).decode()
+        )
+        return InsightResponse(text=out)
 
-@app.get("/v1/healthz")
-def healthz(): return {"status":"ok","version":app.version}
+    @app.post(
+        "/v1/intent_reflector",
+        response_model=InsightResponse,
+        dependencies=[Depends(security.api_key_auth), Depends(security.rate_limiter)],
+    )
+    def intent_reflector(inp: FSUInput) -> InsightResponse:
+        data = inp.model_dump()
+        data["length"] = data.get("length") or cfg.length
+        return InsightResponse(text=generate_insight(FSUInput(**data), cfg))
 
-@app.get("/metrics")
-def metrics(): return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+    @app.post(
+        "/v1/score",
+        response_model=ScoreResponse,
+        dependencies=[Depends(security.api_key_auth), Depends(security.rate_limiter)],
+    )
+    def score(inp: FSUInput) -> ScoreResponse:
+        txt = generate_insight(inp, cfg)
+        s = j_index(
+            inp.intent,
+            txt,
+            cfg.start_phrase,
+            facts=inp.facts,
+            knowledge=inp.knowledge,
+        )
+        return ScoreResponse(text=txt, **s)
 
-@app.exception_handler(ValidationError)
-async def verror(_: Request, exc: ValidationError):
-    return JSONResponse(status_code=422, content={"error":"validation_error","detail":exc.errors()})
+    @app.post(
+        "/v1/stream",
+        dependencies=[Depends(security.api_key_auth), Depends(security.rate_limiter)],
+    )
+    async def stream(inp: FSUInput):
+        txt = generate_insight(inp, cfg)
 
-def run():
+        async def it():
+            yield f"data: {txt}\n\n"
+
+        return StreamingResponse(it(), media_type="text/event-stream")
+
+    @app.post(
+        "/v1/glrtpm/run",
+        response_model=GLResponse,
+        dependencies=[Depends(security.api_key_auth), Depends(security.rate_limiter)],
+    )
+    def glrtpm_run(req: GLRequest) -> GLResponse:
+        spec = ProjectSpec(
+            title=req.title,
+            thesis=req.thesis,
+            roles=req.roles,
+            rounds=req.rounds,
+        )
+        orch = Orchestrator(spec)
+        res = orch.run()
+        return GLResponse(
+            markdown=res["markdown"], html=res["html"], metrics=res["metrics"]
+        )
+
+    @app.get("/v1/healthz")
+    def healthz():
+        return {"status": "ok", "version": app.version}
+
+    @app.get("/metrics")
+    def metrics_endpoint():
+        return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    @app.exception_handler(ValidationError)
+    async def verror(_: Request, exc: ValidationError):
+        return JSONResponse(
+            status_code=422,
+            content={"error": "validation_error", "detail": exc.errors()},
+        )
+
+    return app
+
+
+app = create_app()
+
+
+def run(cfg: FSUConfig | None = None, settings: Settings | None = None):
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+    uvicorn.run(create_app(cfg, settings), host="0.0.0.0", port=8000)
+

--- a/src/factsynth_ultimate/generator.py
+++ b/src/factsynth_ultimate/generator.py
@@ -40,7 +40,8 @@ def _infer_valence(text: str) -> str:
     if any(k in t for k in ["команд","спільнот","зв’яз","віднос"]): return "зв’язок"
     return "досягнення"
 
-def generate_insight(inp: FSUInput, cfg: FSUConfig = FSUConfig()) -> str:
+def generate_insight(inp: FSUInput, cfg: FSUConfig | None = None) -> str:
+    cfg = cfg or FSUConfig()
     L = inp.length or cfg.length
     v = inp.valence if inp.valence in VALENCE else _infer_valence(inp.intent)
     motive = inp.motive or "конкретизація і перевірка корисності"
@@ -81,6 +82,10 @@ def generate_insight(inp: FSUInput, cfg: FSUConfig = FSUConfig()) -> str:
                     forbid_lists=cfg.forbid_lists,
                     forbid_emojis=cfg.forbid_emojis)
     text = fit_length(text, L)
+    if not text.startswith(cfg.start_phrase):
+        prefix = cfg.start_phrase.rstrip("…")
+        if text.startswith(prefix):
+            text = cfg.start_phrase + text[len(prefix):]
     assert count_words(text) == L, f"length mismatch: {count_words(text)} != {L}"
     assert text.startswith(cfg.start_phrase), "must start with start_phrase"
     assert "?" not in text

--- a/src/factsynth_ultimate/security.py
+++ b/src/factsynth_ultimate/security.py
@@ -1,35 +1,47 @@
 from time import time
 from fastapi import Header, HTTPException
+
 try:
     import jwt
-except Exception:
+except Exception:  # pragma: no cover - optional dependency
     jwt = None
+
 from .settings import Settings
-S = Settings()
-_BUCKET = {}
 
-async def api_key_auth(x_api_key: str | None = Header(None), authorization: str | None = Header(None)):
-    if S.API_KEY and x_api_key == S.API_KEY:
-        return
-    if authorization and authorization.startswith("Bearer ") and S.JWT_PUBLIC_KEY and jwt:
-        token = authorization.split(" ",1)[1]
-        try:
-            payload = jwt.decode(token, S.JWT_PUBLIC_KEY, algorithms=[S.JWT_ALG])
-            if S.JWT_REQUIRED_AUD and S.JWT_REQUIRED_AUD not in (payload.get("aud") or []):
-                raise HTTPException(status_code=403, detail="jwt_audience_mismatch")
+
+class Security:
+    """Collection of security dependencies parameterized by :class:`Settings`."""
+
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self._bucket: dict[str, tuple[int, int]] = {}
+
+    async def api_key_auth(self, x_api_key: str | None = Header(None), authorization: str | None = Header(None)):
+        S = self.settings
+        if S.API_KEY and x_api_key == S.API_KEY:
             return
-        except Exception:
-            raise HTTPException(status_code=401, detail="invalid_jwt")
-    raise HTTPException(status_code=401, detail="unauthorized")
+        if authorization and authorization.startswith("Bearer ") and S.JWT_PUBLIC_KEY and jwt:
+            token = authorization.split(" ", 1)[1]
+            try:
+                payload = jwt.decode(token, S.JWT_PUBLIC_KEY, algorithms=[S.JWT_ALG])
+                aud = payload.get("aud") or []
+                if S.JWT_REQUIRED_AUD and S.JWT_REQUIRED_AUD not in aud:
+                    raise HTTPException(status_code=403, detail="jwt_audience_mismatch")
+                return
+            except Exception:
+                raise HTTPException(status_code=401, detail="invalid_jwt")
+        raise HTTPException(status_code=401, detail="unauthorized")
 
-async def rate_limiter(x_api_key: str | None = Header(None)):
-    key = x_api_key or "anon"
-    cap, window = S.RATE_MAX_REQ, S.RATE_WINDOW_SEC
-    now = int(time())
-    tok, ts = _BUCKET.get(key, (cap, now))
-    if now > ts:
-        delta = now - ts
-        tok = min(cap, tok + (cap * delta // window)); ts = now
-    if tok <= 0:
-        raise HTTPException(status_code=429, detail="rate_limited")
-    _BUCKET[key] = (tok - 1, ts)
+    async def rate_limiter(self, x_api_key: str | None = Header(None)):
+        S = self.settings
+        key = x_api_key or "anon"
+        cap, window = S.RATE_MAX_REQ, S.RATE_WINDOW_SEC
+        now = int(time())
+        tok, ts = self._bucket.get(key, (cap, now))
+        if now > ts:
+            delta = now - ts
+            tok = min(cap, tok + (cap * delta // window))
+            ts = now
+        if tok <= 0:
+            raise HTTPException(status_code=429, detail="rate_limited")
+        self._bucket[key] = (tok - 1, ts)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,25 @@
-import threading, time, httpx
-from src.factsynth_ultimate.api import run
+from fastapi.testclient import TestClient
 
-def _spawn():
-    th = threading.Thread(target=run, daemon=True); th.start(); time.sleep(0.8)
+from src.factsynth_ultimate.api import create_app
+from src.factsynth_ultimate.config import FSUConfig
+from src.factsynth_ultimate.settings import Settings
+
 
 def test_endpoints_ok():
-    _spawn()
-    base = "http://127.0.0.1:8000"
-    H = {"x-api-key":"change-me","content-type":"application/json"}
-    r = httpx.get(base+"/v1/healthz")
+    cfg = FSUConfig(start_phrase="Старт")
+    settings = Settings(API_KEY="secret")
+    app = create_app(cfg=cfg, settings=settings)
+    client = TestClient(app)
+    headers = {"x-api-key": settings.API_KEY, "content-type": "application/json"}
+
+    r = client.get("/v1/healthz")
     assert r.status_code == 200
-    r2 = httpx.post(base+"/v1/intent_reflector", headers=H, json={"intent":"Тест","length":100})
-    assert r2.status_code == 200 and "text" in r2.json()
+
+    r2 = client.post(
+        "/v1/intent_reflector",
+        headers=headers,
+        json={"intent": "Тест", "length": 10},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["text"].startswith(cfg.start_phrase)
+


### PR DESCRIPTION
## Summary
- create `create_app` factory to supply `FSUConfig` and `Settings`
- add `Security` class for dependency injection
- allow `generate_insight` to override config
- update API tests to configure custom settings

## Testing
- `PYTHONPATH=. pytest tests/test_contract.py tests/test_metrics.py tests/test_orchestrator.py -q --override-ini="addopts="`
- `PYTHONPATH=. pytest tests/test_api.py -q --override-ini="addopts="` *(fails: The starlette.testclient module requires the httpx package to be installed)*


------
https://chatgpt.com/codex/tasks/task_e_68bc9f6370d8832998d413e69f3933e2