### PR TITLE
feat: make API host and port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ curl -H 'x-api-key: change-me' -H 'content-type: application/json' \
 # UI: відкрий ui/index.html (Insight) або ui/roleplay.html (GLRTPM)
 ```
 
+## Змінні середовища
+
+- `API_KEY` — ключ для авторизації (дефолт `change-me`)
+- `API_HOST` — хост для запуску API (дефолт `0.0.0.0`)
+- `API_PORT` — порт API (дефолт `8000`)
+
 ## Docker
 ```bash
 docker build -t factsynth-ultimate:2.0 .

--- a/src/factsynth_ultimate/api.py
+++ b/src/factsynth_ultimate/api.py
@@ -73,4 +73,4 @@ async def verror(_: Request, exc: ValidationError):
 
 def run():
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host=S.API_HOST, port=S.API_PORT)

--- a/src/factsynth_ultimate/settings.py
+++ b/src/factsynth_ultimate/settings.py
@@ -3,6 +3,8 @@ from typing import List
 class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     API_KEY: str = "change-me"
+    API_HOST: str = "0.0.0.0"
+    API_PORT: int = 8000
     MAX_BODY_BYTES: int = 256_000
     CORS_ALLOW_ORIGINS: List[str] = ["http://localhost:5173","http://127.0.0.1:5173"]
     RATE_WINDOW_SEC: int = 10


### PR DESCRIPTION
## Summary
- allow customizing API bind address via `API_HOST` and `API_PORT`
- document new environment variables in README

## Testing
- ⚠️ `pytest` *(missing `httpx`; `pip install httpx` blocked by 403 proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2c0e4a28832994b2955c7c2431dd