### PR TITLE
Add bootstrap script for full product scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ curl -H 'x-api-key: change-me' -H 'content-type: application/json' \
 # UI: відкрий ui/index.html (Insight) або ui/roleplay.html (GLRTPM)
 ```
 
+## Bootstrap повного продукту
+
+```bash
+scripts/bootstrap_full_product.sh
+```
+
+Скрипт створює каркас: директрії `src/full_product`, `tests/full_product` та workflow `.github/workflows/ci.yml`.
+
 ## Змінні середовища
 
 - `API_KEY` — ключ для авторизації (дефолт `change-me`)

--- a/scripts/bootstrap_full_product.sh
+++ b/scripts/bootstrap_full_product.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+mkdir -p "$REPO_ROOT/src/full_product" "$REPO_ROOT/tests/full_product" "$REPO_ROOT/.github/workflows"
+
+cat <<'PYEOF' > "$REPO_ROOT/src/full_product/__init__.py"
+"""Full product package."""
+PYEOF
+
+cat <<'PYEOF' > "$REPO_ROOT/tests/full_product/test_smoke.py"
+def test_smoke():
+    assert True
+PYEOF
+
+cat <<'YAMLEOF' > "$REPO_ROOT/.github/workflows/ci.yml"
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -e .[dev,ops]
+      - run: pytest
+YAMLEOF
+
+echo "Full product scaffold created."


### PR DESCRIPTION
## Summary
- add `bootstrap_full_product.sh` to scaffold directories, files, and CI workflow
- document bootstrap script usage in README

## Testing
- `pytest` *(fails: No module named 'httpx')*
- `pip install -e .[dev,ops]` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2efa3a548329b34ad5d8af47fa61