### PR TITLE
fix(ci+pages): stabilize deps, create badges dir

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,8 +18,10 @@ jobs:
         run: pip install -e .[dev]
       - name: Run tests
         run: pytest
-      - name: Create badges directory
-        run: mkdir -p site/badges
+      - name: Prepare site directories
+        run: mkdir -p site site/badges site/openapi
+      - name: Copy OpenAPI spec
+        run: cp openapi/openapi.yaml site/openapi/openapi.yaml
       - name: Generate coverage badge
         run: python tools/make_badge.py coverage.xml site/badges/coverage.svg
       - name: Upload artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,12 @@ license = {text = "MIT"}
 requires-python = ">=3.10"
 authors = [{name="Ярослав (Author)", email="author@example.com"}]
 dependencies = [
-  "fastapi>=0.112",
-  "uvicorn[standard]>=0.30",
-  "pydantic>=2.7",
+  "fastapi>=0.110,<0.115",
+  "uvicorn[standard]>=0.24,<0.31",
+  "pydantic>=2,<3",
   "regex>=2024.5.15",
-  "prometheus-client>=0.20",
+  "prometheus-client>=0.16,<1",
+  "requests>=2.31,<3",
   "typer>=0.12",
   "orjson>=3.10",
   "numpy>=1.26",
@@ -23,7 +24,7 @@ dependencies = [
   "markdown>=3.6"
 ]
 [project.optional-dependencies]
-dev = ["pytest>=8.0","pytest-cov>=5.0","ruff>=0.5.0","mypy>=1.10","httpx>=0.27","rich>=13.7"]
+dev = ["pytest>=8.0,<9","pytest-cov>=5.0,<6","ruff>=0.5.0","mypy>=1.10","httpx>=0.27,<0.28","rich>=13.7"]
 ops = ["PyJWT>=2.8"]
 [project.scripts]
 fsu = "factsynth_ultimate.cli:app"


### PR DESCRIPTION
## Summary
- pin core and test dependencies to safe version ranges
- prepare badges/OpenAPI directories during Pages build

## Testing
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `python tools/make_badge.py --xml coverage.xml --out site/badges/coverage.svg` *(fails: No such file or directory: 'coverage.xml')*
- `curl -I https://neuron7x.github.io/FactSynth/badges/coverage.svg` *(fails: CONNECT tunnel failed, response 403)*
- `gh workflow enable ci.yml pages.yml codeql.yml || true` *(fails: command not found)*
- `gh workflow run ci.yml pages.yml codeql.yml` *(fails: command not found)*
- `git tag fix-1 && git push origin fix-1` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68bd331c1e3c8329820dfd1354ffd703