### PR TITLE
Document tokenization regex and add punctuation tests

### DIFF
--- a/src/factsynth_ultimate/tokenization.py
+++ b/src/factsynth_ultimate/tokenization.py
@@ -1,5 +1,60 @@
-import unicodedata, regex as re
-_TOKEN_RE = re.compile(r"[\p{L}\p{N}ʼ'\-]+", re.UNICODE)
-def normalize(text: str) -> str: return unicodedata.normalize("NFC", text)
-def tokenize(text: str) -> list[str]: return _TOKEN_RE.findall(normalize(text))
-def count_words(text: str) -> int: return len(tokenize(text))
+r"""Utilities for Unicode-aware tokenization.
+
+The module exposes a small set of helpers to break text into word and number
+tokens.  All input is first normalised to Unicode NFC form so that characters
+with combining marks are represented consistently.  Tokenisation is performed
+using a single regular expression, ``_TOKEN_RE``:
+
+``r"[\p{L}\p{N}\u02BC'\-]+"``
+
+The pattern matches runs of Unicode letters (``\p{L}``) or digits (``\p{N}``)
+and allows embedded apostrophes (both the ASCII ``'`` and the Ukrainian
+``\u02BC``) as well as hyphens.  Any other punctuation or whitespace acts as a
+separator.
+Because the pattern relies on Unicode categories, text containing multiple
+languages is handled naturally; for example, ``"Hola мир 42"`` tokenises to
+``["Hola", "мир", "42"]``.
+"""
+
+import unicodedata
+
+import regex as re
+
+_TOKEN_RE = re.compile(r"[\p{L}\p{N}\u02BC'\-]+", re.UNICODE)
+
+
+def normalize(text: str) -> str:
+    """Return *text* normalised to Unicode NFC form.
+
+    Canonical composition via :func:`unicodedata.normalize` ensures that
+    equivalent character sequences across different languages use the same
+    binary representation.  This is important when processing mixed-language
+    text where combining marks might otherwise produce distinct tokens.
+    """
+
+    return unicodedata.normalize("NFC", text)
+
+
+def tokenize(text: str) -> list[str]:
+    """Split *text* into a list of tokens.
+
+    The input is first passed through :func:`normalize` and then matched against
+    ``_TOKEN_RE``.  Tokens consist of consecutive letters or digits and may
+    include internal apostrophes or hyphens.  Punctuation other than these
+    characters acts as a delimiter.  Because the regular expression operates on
+    Unicode properties, tokens are produced correctly for mixed-language input
+    such as ``"naïve 世界 123"``.
+    """
+
+    return _TOKEN_RE.findall(normalize(text))
+
+
+def count_words(text: str) -> int:
+    """Return the number of tokens found in *text*.
+
+    This simply counts the results of :func:`tokenize`, so numbers and words
+    separated by punctuation are all considered individual tokens.
+    """
+
+    return len(tokenize(text))
+

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,0 +1,17 @@
+from src.factsynth_ultimate.tokenization import count_words, tokenize
+
+
+def test_tokenize_handles_punctuation() -> None:
+    text = "Hello, world! state-of-the-art."
+    assert tokenize(text) == ["Hello", "world", "state-of-the-art"]
+
+
+def test_tokenize_handles_numeric_tokens() -> None:
+    text = "Version 2.0 costs 3,000 dollars."
+    assert tokenize(text) == ["Version", "2", "0", "costs", "3", "000", "dollars"]
+
+
+def test_count_words_counts_numeric_tokens() -> None:
+    text = "Numbers: 1, 2, and 3."
+    expected = 5
+    assert count_words(text) == expected


### PR DESCRIPTION
## Summary
- document Unicode-aware tokenization module and functions, including NFC normalization and regex pattern `[\p{L}\p{N}\u02BC'\-]+`
- add tests for punctuation and numeric token handling

## Testing
- `ruff check src/factsynth_ultimate/tokenization.py tests/test_tokenization.py`
- `pytest tests/test_tokenization.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*

------
https://chatgpt.com/codex/tasks/task_e_68bd373f5c0c83299f7c10a81f8b3d56