### PR TITLE
docs: document FSUConfig configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ curl -H 'x-api-key: change-me' -H 'content-type: application/json' \
 # UI: відкрий ui/index.html (Insight) або ui/roleplay.html (GLRTPM)
 ```
 
+## Конфігурація виконання
+
+Генератор приймає обʼєкт [`FSUConfig`](src/factsynth_ultimate/config.py), який
+визначає мову, довжину та інші правила формату. Docstring класу описує призначення
+кожного поля та значення за замовчуванням, тож ви можете змінювати їх перед
+викликом `generate_insight` чи зверненням до API.
+
 ## Bootstrap повного продукту
 
 ```bash

--- a/src/factsynth_ultimate/config.py
+++ b/src/factsynth_ultimate/config.py
@@ -1,5 +1,22 @@
 from pydantic import BaseModel
+
+
 class FSUConfig(BaseModel):
+    """Runtime configuration for FactSynth Ultimate.
+
+    Attributes:
+        language: Output language code. Defaults to ``"uk"``.
+        length: Target number of words in the generated insight. Defaults to ``100``.
+        start_phrase: Text prepended to every generated insight. Defaults to
+            ``"Ти хочеш від мене…"``.
+        forbid_questions: If ``True``, question marks are disallowed. Defaults to ``True``.
+        forbid_headings: If ``True``, heading formatting is removed. Defaults to ``True``.
+        forbid_lists: If ``True``, bullet or numbered lists are disallowed. Defaults to ``True``.
+        forbid_emojis: If ``True``, emoji characters are stripped. Defaults to ``True``.
+        fallback_assumption: Placeholder assumption used when input data is incomplete.
+            Defaults to ``"дані частково відсутні; мета — визнання через новизну"``.
+    """
+
     language: str = "uk"
     length: int = 100
     start_phrase: str = "Ти хочеш від мене…"


### PR DESCRIPTION
## Summary
- document every field in `FSUConfig` with a descriptive class docstring
- add README guidance pointing to `FSUConfig` for runtime tuning

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `ruff check .` *(fails: Found 219 errors)*
- `mypy src` *(fails: Library stubs not installed for "markdown" and "yaml")*

------
https://chatgpt.com/codex/tasks/task_e_68bd37400e088329bae1e2fa855307a5