### PR TITLE
docs: expand formatting helper docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ curl -H 'x-api-key: change-me' -H 'content-type: application/json' \
 кожного поля та значення за замовчуванням, тож ви можете змінювати їх перед
 викликом `generate_insight` чи зверненням до API.
 
+### Formatting helpers
+
+The module [`formatting`](src/factsynth_ultimate/formatting.py) provides small
+utilities for cleaning free-form text.  Use `sanitize()` to strip headings,
+lists or emojis, `ensure_period()` to finalise sentences and `fit_length()` to
+pad or trim a fragment to an exact word count.
+
 ## Bootstrap повного продукту
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify formatting helper usage and intent
- document sanitize/ensure_period/fit_length with examples
- mention formatting utilities in README

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68bd35849c908329a6ff855e49d3bafe