### PR TITLE
Add test optional deps and update pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,9 +17,7 @@ jobs:
         with: { python-version: "3.11" }
 
       - name: Install deps
-        run: |
-          python -m pip install -U pip
-          if [ -f pyproject.toml ]; then pip install -e .[test] || pip install -e .; fi
+        run: pip install -e .[test]
 
       - name: Run tests with coverage
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.5.0", "mypy>=1.10", "httpx>=0.27", "rich>=13.7"]
+test = ["pytest>=8.0", "pytest-cov>=5.0", "requests>=2.31"]
 ops = ["PyJWT>=2.8"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add `test` optional dependency group for pytest and requests
- simplify pages workflow to install only test extras

## Testing
- `pip install -e .[test]`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdae01d6f083299b2b32740738322f