### PR TITLE
Use dev extras in Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
         with: { python-version: "3.11" }
 
       - name: Install deps
-        run: pip install -e .[test]
+        run: pip install -e .[dev]
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
## Summary
- use dev extras for pages workflow dependency installation

## Testing
- `pip install -e .[dev]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd01e586483298bae8ef2205d591f