### PR TITLE
ci: use dev extras for GitHub Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
         with: { python-version: "3.11" }
 
       - name: Install deps
-        run: pip install -e .[dev]
+        run: pip install -e '.[dev]'
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
## Summary
- quote dev extras for GitHub Pages workflow

## Testing
- `pip install -e '.[dev]'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd501404483299ac406df41920f7a