### PR TITLE
Clean unused imports and expose package version endpoint

### DIFF
--- a/src/factsynth_ultimate/schemas/requests.py
+++ b/src/factsynth_ultimate/schemas/requests.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
-from pydantic import BaseModel, Field, conint, constr, field_validator
+
 from typing import List, Optional
 
+from pydantic import BaseModel, Field, conint, constr
+
+
 class IntentReq(BaseModel):
-    intent: constr(strip_whitespace=True, min_length=1)  # noqa: F722
-    length: conint(ge=1, le=1000) = 100  # noqa: F722
+    intent: constr(strip_whitespace=True, min_length=1)
+    length: conint(ge=1, le=1000) = 100
 
 class ScoreReq(BaseModel):
-    text: constr(strip_whitespace=True, min_length=0) = ""  # noqa: F722
-    targets: Optional[List[constr(strip_whitespace=True, min_length=1)]] = None  # noqa: F722
+    text: constr(strip_whitespace=True, min_length=0) = ""
+    targets: Optional[List[constr(strip_whitespace=True, min_length=1)]] = None
     callback_url: Optional[str] = None
 
 class ScoreBatchReq(BaseModel):
@@ -17,5 +20,5 @@ class ScoreBatchReq(BaseModel):
     limit: conint(ge=1, le=10000) = 1000  # soft guard
 
 class GLRTPMReq(BaseModel):
-    text: constr(strip_whitespace=True, min_length=0) = ""  # noqa: F722
+    text: constr(strip_whitespace=True, min_length=0) = ""
     callback_url: Optional[str] = None

--- a/src/factsynth_ultimate/services/runtime.py
+++ b/src/factsynth_ultimate/services/runtime.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
-import math, re, time, json, hashlib
+
+import math
+import re
+import time
 from collections import Counter
-from typing import Dict, Any, Iterable
+from typing import Any, Dict, Iterable
+
 from ..core.metrics import SCORING_TIME
 from ..schemas.requests import ScoreReq
 
@@ -25,10 +29,12 @@ def reflect_intent(intent: str, length: int) -> str:
     return intent[:max(0,length)]
 
 def _coverage(text: str, targets: Iterable[str]) -> float:
-    if not targets: return 0.0
+    if not targets:
+        return 0.0
     words = set(_WORD_RE.findall(text.lower()))
     toks = [t.lower() for t in targets if t]
-    if not toks: return 0.0
+    if not toks:
+        return 0.0
     found = sum(1 for t in toks if t in words)
     return found / len(toks)
 


### PR DESCRIPTION
## Summary
- remove unused imports in runtime and schema modules
- expose package version via `/v1/version`
- tidy API router imports and comments

## Testing
- `ruff check src/factsynth_ultimate/api/routers.py src/factsynth_ultimate/services/runtime.py src/factsynth_ultimate/schemas/requests.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be603bdfb08329aa5189280fe7cdd9