### PR TITLE
Use monotonic clock for rate limit buckets

### DIFF
--- a/src/factsynth_ultimate/core/ratelimit.py
+++ b/src/factsynth_ultimate/core/ratelimit.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import time
+from time import monotonic
 from collections import defaultdict, deque
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -26,7 +26,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if path.startswith(("/v1/healthz","/metrics")):
             return await call_next(request)
         key = self._key(request)
-        now = time.time()
+        now = monotonic()
         window_start = now - 60.0
         q = self.buckets[key]
         while q and q[0] < window_start:


### PR DESCRIPTION
## Summary
- Import `monotonic` from the `time` module for rate limit timing
- Use the monotonic clock instead of `time.time()` to track bucket usage

## Testing
- `ruff check src/factsynth_ultimate/core/ratelimit.py` *(fails: Import block is un-sorted or un-formatted; multiple existing lint issues)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be603ca7fc8329a00c51d046fb08f3