### PR TITLE
refactor tests to use TestClient

### DIFF
--- a/tests/test_score_and_auth.py
+++ b/tests/test_score_and_auth.py
@@ -1,53 +1,25 @@
-import time
 from http import HTTPStatus
-from multiprocessing import Process
-
-import httpx
-import uvicorn
-
+from fastapi.testclient import TestClient
 from factsynth_ultimate.app import create_app
 
 
-def run_server(port: int):
-    uvicorn.run(create_app(), host="127.0.0.1", port=port, log_level="warning")
-
-
-def start_server(port: int) -> Process:
-    proc = Process(target=run_server, args=(port,), daemon=True)
-    proc.start()
-    for _ in range(50):
-        try:
-            httpx.get(f"http://127.0.0.1:{port}/v1/healthz")
-            break
-        except httpx.ConnectError:
-            time.sleep(0.1)
-    return proc
-
-
 def test_auth_required():
-    port = 8001
-    proc = start_server(port)
-    url = f"http://127.0.0.1:{port}/v1/score"
-    assert httpx.post(url, json={"text": "x"}).status_code == HTTPStatus.UNAUTHORIZED
-    assert (
-        httpx.post(url, headers={"x-api-key": "change-me"}, json={"text": "x"}).status_code
-        == HTTPStatus.OK
-    )
-    proc.terminate()
-    proc.join()
+    with TestClient(create_app()) as client:
+        url = "/v1/score"
+        assert client.post(url, json={"text": "x"}).status_code == HTTPStatus.UNAUTHORIZED
+        assert (
+            client.post(url, headers={"x-api-key": "change-me"}, json={"text": "x"}).status_code
+            == HTTPStatus.OK
+        )
 
 
 def test_score_values():
-    port = 8002
-    proc = start_server(port)
-    url = f"http://127.0.0.1:{port}/v1/score"
-    r = httpx.post(
-        url,
-        headers={"x-api-key": "change-me"},
-        json={"text": "hello world", "targets": ["hello", "x"]},
-    )
-    proc.terminate()
-    proc.join()
-    assert r.status_code == HTTPStatus.OK
-    s = r.json()["score"]
-    assert 0.0 <= s <= 1.0
+    with TestClient(create_app()) as client:
+        r = client.post(
+            "/v1/score",
+            headers={"x-api-key": "change-me"},
+            json={"text": "hello world", "targets": ["hello", "x"]},
+        )
+        assert r.status_code == HTTPStatus.OK
+        s = r.json()["score"]
+        assert 0.0 <= s <= 1.0

--- a/tests/test_stream_sse.py
+++ b/tests/test_stream_sse.py
@@ -1,39 +1,14 @@
-import time
 from http import HTTPStatus
-from multiprocessing import Process
-
-import httpx
-import uvicorn
-
+from fastapi.testclient import TestClient
 from factsynth_ultimate.app import create_app
 
 
-def run_server(port: int):
-    uvicorn.run(create_app(), host="127.0.0.1", port=port, log_level="warning")
-
-
-def start_server(port: int) -> Process:
-    proc = Process(target=run_server, args=(port,), daemon=True)
-    proc.start()
-    for _ in range(50):
-        try:
-            httpx.get(f"http://127.0.0.1:{port}/v1/healthz")
-            break
-        except httpx.ConnectError:
-            time.sleep(0.1)
-    return proc
-
-
 def test_stream_sse():
-    port = 8003
-    proc = start_server(port)
-    url = f"http://127.0.0.1:{port}/v1/stream"
-    with httpx.stream(
-        "POST", url, headers={"x-api-key": "change-me"}, json={"text": "abc"}
-    ) as r:
-        body = b"".join(r.iter_bytes())
-        status = r.status_code
-    proc.terminate()
-    proc.join()
+    with TestClient(create_app()) as client:
+        with client.stream(
+            "POST", "/v1/stream", headers={"x-api-key": "change-me"}, json={"text": "abc"}
+        ) as r:
+            body = b"".join(r.iter_bytes())
+            status = r.status_code
     assert status == HTTPStatus.OK
     assert b"event: start" in body and b"event: end" in body


### PR DESCRIPTION
## Summary
- switch tests to TestClient(create_app()) instead of spawning uvicorn subprocesses
- use TestClient request methods and drop multiprocessing/port handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be603e87408329a1c9aa99913b27be