### PR TITLE
feat: add configurable rate limit cleanup

### DIFF
--- a/src/factsynth_ultimate/app.py
+++ b/src/factsynth_ultimate/app.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import time
+
 from fastapi import FastAPI, Response
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from .api.routers import api
 from .core.auth import APIKeyAuthMiddleware
@@ -9,11 +12,10 @@ from .core.body_limit import BodySizeLimitMiddleware
 from .core.errors import install_handlers
 from .core.logging import setup_logging
 from .core.metrics import LATENCY, REQUESTS, metrics_bytes, metrics_content_type
+from .core.ratelimit import RateLimitMiddleware
 from .core.request_id import RequestIDMiddleware
 from .core.security_headers import SecurityHeadersMiddleware
 from .core.settings import load_settings
-from .core.ratelimit import RateLimitMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
 
 
 class _MetricsMiddleware(BaseHTTPMiddleware):
@@ -25,11 +27,9 @@ class _MetricsMiddleware(BaseHTTPMiddleware):
         start = time.perf_counter()
         response = await call_next(request)
         duration = max(0.0, time.perf_counter() - start)
-        try:
+        with contextlib.suppress(Exception):
             REQUESTS.labels(method, path, str(response.status_code)).inc()
             LATENCY.labels(path).observe(duration)
-        except Exception:
-            pass
         return response
 
 
@@ -66,6 +66,8 @@ def create_app() -> FastAPI:
         RateLimitMiddleware,
         per_minute=settings.ratelimit_per_minute,
         key_header=settings.auth_header_name,
+        cleanup_minutes=settings.ratelimit_bucket_ttl,
+        cleanup_every=settings.ratelimit_cleanup_every,
     )
     app.add_middleware(_MetricsMiddleware)
 

--- a/src/factsynth_ultimate/core/ratelimit.py
+++ b/src/factsynth_ultimate/core/ratelimit.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
+
+import contextlib
 import time
 from collections import defaultdict, deque
+
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
+
 from .metrics import REQUESTS
 
+
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, per_minute: int = 120, key_header: str = "x-api-key"):
+    def __init__(
+        self,
+        app,
+        per_minute: int = 120,
+        key_header: str = "x-api-key",
+        cleanup_minutes: int = 15,
+        cleanup_every: int = 100,
+    ):
         super().__init__(app)
         self.per_minute = per_minute
         self.key_header = key_header
+        self.cleanup_minutes = cleanup_minutes
+        self.cleanup_every = cleanup_every
         self.buckets = defaultdict(deque)
+        self._count = 0
 
     def _key(self, request: Request) -> str:
         return request.headers.get(self.key_header) or (request.client.host if request.client else "anon")
@@ -32,16 +47,25 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         while q and q[0] < window_start:
             q.popleft()
         if len(q) >= self.per_minute:
-            try: REQUESTS.labels(request.method, path, "429").inc()
-            except Exception: pass
+            with contextlib.suppress(Exception):
+                REQUESTS.labels(request.method, path, "429").inc()
             resp = JSONResponse({"type":"about:blank","title":"Too Many Requests","status":429}, status_code=429, media_type="application/problem+json")
             resp.headers["Retry-After"] = "60"
             self._set_headers(resp, used=len(q))
             return resp
         q.append(now)
+        self._count += 1
+        if self._count % self.cleanup_every == 0:
+            self._cleanup(now)
         response = await call_next(request)
         self._set_headers(response, used=len(q))
-        # періодичне прибирання старих ключів
-        if len(self.buckets) > 10000 and not q:  # грубе обмеження
-            self.buckets.pop(key, None)
         return response
+
+    def _cleanup(self, now: float) -> None:
+        window_start = now - 60.0
+        expire_before = now - self.cleanup_minutes * 60.0
+        for key, q in list(self.buckets.items()):
+            while q and q[0] < window_start:
+                q.popleft()
+            if not q or q[-1] < expire_before:
+                self.buckets.pop(key, None)

--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 import os
 from dataclasses import dataclass
+
 
 @dataclass
 class Settings:
@@ -10,6 +12,8 @@ class Settings:
     auth_header_name: str = os.getenv("AUTH_HEADER_NAME", "x-api-key")
     skip_auth_paths: str = os.getenv("SKIP_AUTH_PATHS", "/v1/healthz,/metrics")
     ratelimit_per_minute: int = int(os.getenv("RATE_LIMIT_PER_MINUTE", "120"))
+    ratelimit_bucket_ttl: int = int(os.getenv("RATE_LIMIT_BUCKET_TTL", "15"))
+    ratelimit_cleanup_every: int = int(os.getenv("RATE_LIMIT_CLEANUP_EVERY", "100"))
     health_tcp_checks: str = os.getenv("HEALTH_TCP_CHECKS", "")
 
 def load_settings() -> Settings:


### PR DESCRIPTION
## Summary
- add configurable ratelimit bucket cleanup
- expose cleanup ttl and frequency in settings
- wire settings into middleware

## Testing
- `ruff check src/factsynth_ultimate/core/ratelimit.py src/factsynth_ultimate/core/settings.py src/factsynth_ultimate/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be60427c58832990ecba3c33022229