### PR TITLE
Add configurable bucket cleanup to rate limiter

### DIFF
--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
+
 import os
 from dataclasses import dataclass
 
+
 @dataclass
 class Settings:
+    """Runtime configuration sourced from environment variables."""
+
     env: str = os.getenv("ENV", "dev")
     https_redirect: bool = os.getenv("HTTPS_REDIRECT", "false").lower() == "true"
     cors_allow_origins: str = os.getenv("CORS_ALLOW_ORIGINS", "*")
     auth_header_name: str = os.getenv("AUTH_HEADER_NAME", "x-api-key")
     skip_auth_paths: str = os.getenv("SKIP_AUTH_PATHS", "/v1/healthz,/metrics")
     ratelimit_per_minute: int = int(os.getenv("RATE_LIMIT_PER_MINUTE", "120"))
+    ratelimit_bucket_ttl: float = float(os.getenv("RATE_LIMIT_BUCKET_TTL", "300"))
+    ratelimit_cleanup_interval: float = float(os.getenv("RATE_LIMIT_CLEANUP_INTERVAL", "60"))
     health_tcp_checks: str = os.getenv("HEALTH_TCP_CHECKS", "")
 
 def load_settings() -> Settings:


### PR DESCRIPTION
## Summary
- add bucket TTL and cleanup interval settings
- purge expired rate-limit buckets using monotonic clock
- enforce positive bucket timing and add type hints across rate limiter

## Testing
- `ruff check src/factsynth_ultimate/app.py src/factsynth_ultimate/core/ratelimit.py src/factsynth_ultimate/core/settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd85d77f88329bf1b2357ea12c751