### PR TITLE
feat: load API key from secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ curl -s http://127.0.0.1:8000/metrics
 
 ## Auth & Rate Limits
 
+* API key sources: `API_KEY_FILE` → Vault → `API_KEY` → default `change-me` (dev only)
 * Auth: `x-api-key: <your-secret>`
 * Default skip list (no auth): `/v1/healthz`, `/metrics`, `/v1/version`
 * Rate limit: `RATE_LIMIT_PER_MIN` (default **120**) per API key / client IP

--- a/src/factsynth_ultimate/app.py
+++ b/src/factsynth_ultimate/app.py
@@ -16,6 +16,7 @@ from .core.ratelimit import RateLimitMiddleware
 from .core.request_id import RequestIDMiddleware
 from .core.security_headers import SecurityHeadersMiddleware
 from .core.settings import load_settings
+from .core.secrets import read_api_key
 
 
 class _MetricsMiddleware(BaseHTTPMiddleware):
@@ -61,7 +62,7 @@ def create_app(
     app.add_middleware(BodySizeLimitMiddleware)
     app.add_middleware(
         APIKeyAuthMiddleware,
-        api_key="change-me",
+        api_key=read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY"),
         header_name=settings.auth_header_name,
         skip=tuple(settings.skip_auth_paths.split(",")),
     )

--- a/tests/test_score_and_auth.py
+++ b/tests/test_score_and_auth.py
@@ -1,25 +1,30 @@
 from http import HTTPStatus
+import os
+from unittest.mock import patch
+
 from fastapi.testclient import TestClient
 from factsynth_ultimate.app import create_app
 
 
 def test_auth_required():
-    with TestClient(create_app()) as client:
-        url = "/v1/score"
-        assert client.post(url, json={"text": "x"}).status_code == HTTPStatus.UNAUTHORIZED
-        assert (
-            client.post(url, headers={"x-api-key": "change-me"}, json={"text": "x"}).status_code
-            == HTTPStatus.OK
-        )
+    with patch.dict(os.environ, {"API_KEY": "secret"}):
+        with TestClient(create_app()) as client:
+            url = "/v1/score"
+            assert client.post(url, json={"text": "x"}).status_code == HTTPStatus.UNAUTHORIZED
+            assert (
+                client.post(url, headers={"x-api-key": "secret"}, json={"text": "x"}).status_code
+                == HTTPStatus.OK
+            )
 
 
 def test_score_values():
-    with TestClient(create_app()) as client:
-        r = client.post(
-            "/v1/score",
-            headers={"x-api-key": "change-me"},
-            json={"text": "hello world", "targets": ["hello", "x"]},
-        )
-        assert r.status_code == HTTPStatus.OK
-        s = r.json()["score"]
-        assert 0.0 <= s <= 1.0
+    with patch.dict(os.environ, {"API_KEY": "secret"}):
+        with TestClient(create_app()) as client:
+            r = client.post(
+                "/v1/score",
+                headers={"x-api-key": "secret"},
+                json={"text": "hello world", "targets": ["hello", "x"]},
+            )
+            assert r.status_code == HTTPStatus.OK
+            s = r.json()["score"]
+            assert 0.0 <= s <= 1.0


### PR DESCRIPTION
## Summary
- load API key via `read_api_key` supporting env var and file
- document auth configuration
- test auth with correct API key

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be7b1d8f8c8329b7eee8ca217d74c0