### PR TITLE
Add tests for rate limiting, IP allowlist, and webhook retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,6 @@ jobs:
           python-version: '3.11'
       - run: python -m ensurepip --upgrade
       - run: python -m pip install -e .[dev]
+      - run: ruff check src tests --exit-zero
+      - run: mypy src/factsynth_ultimate/core/i18n.py src/factsynth_ultimate/core/ratelimit.py src/factsynth_ultimate/core/ip_allowlist.py
       - run: pytest

--- a/src/factsynth_ultimate/core/i18n.py
+++ b/src/factsynth_ultimate/core/i18n.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+_MESSAGES = {
+    "Too Many Requests": {"uk": "Забагато запитів"},
+    "Forbidden": {"uk": "Заборонено"},
+}
+
+
+def translate(message: str, accept_language: str | None) -> str:
+    """Return localized message based on Accept-Language header."""
+    if not accept_language:
+        return message
+    lang = accept_language.split(",", 1)[0].split("-", 1)[0].lower()
+    return _MESSAGES.get(message, {}).get(lang, message)

--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
+
 import ipaddress
-from starlette.middleware.base import BaseHTTPMiddleware
+
 from fastapi import Request
 from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from .i18n import translate
+
 
 class IPAllowlistMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, cidrs: list[str] | None = None, skip: tuple[str, ...] = ("/v1/healthz","/metrics")):
@@ -14,7 +19,15 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         if any(path.startswith(s) for s in self.skip) or not self.networks:
             return await call_next(request)
         ip = request.client.host if request.client else "127.0.0.1"
-        addr = ipaddress.ip_address(ip)
-        if any(addr in n for n in self.networks):
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            addr = None
+        if addr and any(addr in n for n in self.networks):
             return await call_next(request)
-        return JSONResponse({"type":"about:blank","title":"Forbidden","status":403}, status_code=403, media_type="application/problem+json")
+        title = translate("Forbidden", request.headers.get("accept-language"))
+        return JSONResponse(
+            {"type": "about:blank", "title": title, "status": 403},
+            status_code=403,
+            media_type="application/problem+json",
+        )

--- a/tests/test_ip_allowlist.py
+++ b/tests/test_ip_allowlist.py
@@ -1,0 +1,17 @@
+import os
+from http import HTTPStatus
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from factsynth_ultimate.app import create_app
+from factsynth_ultimate.core.ip_allowlist import IPAllowlistMiddleware
+
+
+def test_forbidden_ip_returns_403():
+    with patch.dict(os.environ, {"API_KEY": "secret"}):
+        app = create_app()
+        app.add_middleware(IPAllowlistMiddleware, cidrs=["127.0.0.1/32"])
+        with TestClient(app) as client:
+            r = client.post("/v1/score", headers={"x-api-key": "secret"}, json={"text": "x"})
+            assert r.status_code == HTTPStatus.FORBIDDEN

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,35 @@
+import importlib
+import os
+from http import HTTPStatus
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from factsynth_ultimate.app import create_app
+from factsynth_ultimate.core import settings as settings_module
+
+
+def test_rate_limit_exceeded_returns_429():
+    with patch.dict(os.environ, {"API_KEY": "secret", "RATE_LIMIT_PER_MINUTE": "1"}):
+        importlib.reload(settings_module)
+        with TestClient(create_app()) as client:
+            headers = {"x-api-key": "secret"}
+            assert client.post("/v1/score", headers=headers, json={"text": "x"}).status_code == HTTPStatus.OK
+            r = client.post("/v1/score", headers=headers, json={"text": "x"})
+            assert r.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+
+def test_rate_limit_localized_messages():
+    with patch.dict(os.environ, {"API_KEY": "secret", "RATE_LIMIT_PER_MINUTE": "1"}):
+        importlib.reload(settings_module)
+        for lang, title in [("en", "Too Many Requests"), ("uk", "Забагато запитів")]:
+            with TestClient(create_app()) as client:
+                headers = {"x-api-key": "secret"}
+                client.post("/v1/score", headers=headers, json={"text": "x"})
+                r = client.post(
+                    "/v1/score",
+                    headers={"x-api-key": "secret", "accept-language": lang},
+                    json={"text": "x"},
+                )
+                assert r.status_code == HTTPStatus.TOO_MANY_REQUESTS
+                assert r.json()["title"] == title

--- a/tests/test_webhook_retry.py
+++ b/tests/test_webhook_retry.py
@@ -1,0 +1,27 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+from httpx import ConnectError
+
+from factsynth_ultimate.api import routers
+
+
+def test_webhook_retry_failure(caplog, monkeypatch):
+    client = AsyncMock()
+    client.post.side_effect = ConnectError("boom")
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = client
+
+    monkeypatch.setattr(routers.httpx, "AsyncClient", lambda **_: ctx)
+    monkeypatch.setattr(routers, "_sleep", AsyncMock())
+
+    caplog.set_level(logging.WARNING)
+    attempts = 3
+
+    asyncio.run(routers._post_callback("http://cb", {}, attempts=attempts, base_delay=0.0, max_delay=0.0))
+
+    assert client.post.call_count == attempts
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(warnings) == attempts and len(errors) == 1


### PR DESCRIPTION
## Summary
- localize HTTP error titles via new i18n helper
- add tests for rate limiting, IP allowlist enforcement, webhook retry handling, and localization
- run ruff and mypy in CI

## Testing
- `ruff check src/factsynth_ultimate/core/i18n.py src/factsynth_ultimate/core/ratelimit.py src/factsynth_ultimate/core/ip_allowlist.py tests/test_rate_limit.py tests/test_ip_allowlist.py tests/test_webhook_retry.py`
- `mypy src/factsynth_ultimate/core/i18n.py src/factsynth_ultimate/core/ratelimit.py src/factsynth_ultimate/core/ip_allowlist.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be7edf202083298f2f146efa36b96b