### PR TITLE
Fix mypy errors by refining type hints

### DIFF
--- a/examples/python/sdk_example.py
+++ b/examples/python/sdk_example.py
@@ -1,5 +1,7 @@
-# Python SDK example (minimal, without generator)
-import os, requests
+"""Minimal Python SDK example."""
+
+import os
+import requests  # type: ignore[import-untyped]
 
 API = os.getenv("FACTSYNTH_API", "http://localhost:8000")
 

--- a/src/factsynth_ultimate/core/ratelimit.py
+++ b/src/factsynth_ultimate/core/ratelimit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict, deque
+from typing import Deque, DefaultDict
 from contextlib import suppress
 from time import monotonic
 
@@ -33,7 +34,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self.key_header = key_header
         self.bucket_ttl = bucket_ttl
         self.cleanup_interval = cleanup_interval
-        self.buckets = defaultdict(deque)
+        self.buckets: DefaultDict[str, Deque[float]] = defaultdict(deque)
         self._next_cleanup = monotonic() + cleanup_interval
 
     def _key(self, request: Request) -> str:

--- a/src/factsynth_ultimate/schemas/requests.py
+++ b/src/factsynth_ultimate/schemas/requests.py
@@ -1,24 +1,30 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
-from pydantic import BaseModel, Field, conint, constr
+from pydantic import BaseModel, Field
+
+
+StrippedNonEmpty = Annotated[str, Field(strip_whitespace=True, min_length=1)]
+NonNegativeStr = Annotated[str, Field(strip_whitespace=True, min_length=0)]
+LimitedInt = Annotated[int, Field(ge=1, le=1000)]
+LargeInt = Annotated[int, Field(ge=1, le=10000)]
 
 
 class IntentReq(BaseModel):
-    intent: constr(strip_whitespace=True, min_length=1)
-    length: conint(ge=1, le=1000) = 100
+    intent: StrippedNonEmpty
+    length: LimitedInt = 100
 
 class ScoreReq(BaseModel):
-    text: constr(strip_whitespace=True, min_length=0) = ""
-    targets: Optional[List[constr(strip_whitespace=True, min_length=1)]] = None
+    text: NonNegativeStr = ""
+    targets: Optional[List[StrippedNonEmpty]] = None
     callback_url: Optional[str] = None
 
 class ScoreBatchReq(BaseModel):
     items: List[ScoreReq] = Field(default_factory=list)
     callback_url: Optional[str] = None
-    limit: conint(ge=1, le=10000) = 1000  # soft guard
+    limit: LargeInt = 1000  # soft guard
 
 class GLRTPMReq(BaseModel):
-    text: constr(strip_whitespace=True, min_length=0) = ""
+    text: NonNegativeStr = ""
     callback_url: Optional[str] = None


### PR DESCRIPTION
## Summary
- clarify SDK example imports to satisfy mypy
- replace Pydantic constraint helpers with Annotated fields
- annotate rate limit buckets

## Testing
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factsynth_ultimate')*

------
https://chatgpt.com/codex/tasks/task_e_68be84839f1883299ab1f415a884eb89