### PR TITLE
Expose package version constant

### DIFF
--- a/src/factsynth_ultimate/__init__.py
+++ b/src/factsynth_ultimate/__init__.py
@@ -1,0 +1,9 @@
+"""factsynth_ultimate package initialization."""
+from importlib import metadata
+
+try:
+    VERSION = metadata.version("factsynth-ultimate-pro")
+except metadata.PackageNotFoundError:  # pragma: no cover - fallback for dev
+    VERSION = "0.0.0"
+
+__all__ = ["VERSION"]

--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -20,9 +20,9 @@ logger=logging.getLogger(__name__)
 
 api=APIRouter()
 
-@api.get('/v1/version')
-def version():
-    return {'name':'factsynth-ultimate-pro','version': VERSION}
+@api.get("/v1/version")
+def version() -> dict[str, str]:
+    return {"name": "factsynth-ultimate-pro", "version": VERSION}
 
 @api.post('/v1/intent_reflector')
 def intent_reflector(req: IntentReq, request: Request):


### PR DESCRIPTION
## Summary
- expose package metadata as `VERSION`
- clean up `/v1/version` endpoint to use the constant

## Testing
- `ruff check src/factsynth_ultimate/__init__.py src/factsynth_ultimate/api/routers.py`
- `mypy src/factsynth_ultimate/__init__.py src/factsynth_ultimate/api/routers.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy'; NameError: name 'try_enable_otel' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68beb2d853b88329a82bee4c2b963389