### PR TITLE
Add tokenization utilities and regex dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "prometheus-client",
+    "regex",
 ]
 
 [project.optional-dependencies]

--- a/src/factsynth_ultimate/tokenization.py
+++ b/src/factsynth_ultimate/tokenization.py
@@ -1,0 +1,43 @@
+"""Minimal text normalization and tokenization utilities.
+
+These helpers are intentionally lightweight so they can be reused by the API,
+CLI and other parts of the project without pulling in heavy dependencies.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import List
+
+import regex as re
+
+# Matches runs of Unicode word characters (letters, marks, digits, underscore).
+_WORD_RE = re.compile(r"\w+", flags=re.UNICODE)
+# Collapses any whitespace sequence into a single space.
+_SPACE_RE = re.compile(r"\s+")
+
+
+def normalize(text: str) -> str:
+    """Return a Unicode-normalized, whitespace-collapsed string.
+
+    The function applies NFC/KC normalization, replaces non-breaking spaces with
+    regular spaces and collapses consecutive whitespace into a single space.
+    Leading and trailing whitespace is stripped from the result.
+    """
+    if not text:
+        return ""
+    t = unicodedata.normalize("NFKC", text)
+    t = t.replace("\u00a0", " ")
+    t = _SPACE_RE.sub(" ", t)
+    return t.strip()
+
+
+def tokenize(text: str) -> List[str]:
+    """Split ``text`` into individual word tokens.
+
+    The input is first :func:`normalize`d. Tokens are defined as runs of Unicode
+    word characters (letters, digits or underscore). The returned list preserves
+    the original order of tokens.
+    """
+    norm = normalize(text)
+    return _WORD_RE.findall(norm)


### PR DESCRIPTION
## Summary
- implement lightweight text normalization and tokenization helpers
- add `regex` to project dependencies

## Testing
- `ruff check src/factsynth_ultimate/tokenization.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy'; ImportError: cannot import name 'VERSION')*


------
https://chatgpt.com/codex/tasks/task_e_68beb2d96ac8832998331efe142695dd