### PR TITLE
chore: remove poetry dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,3 @@ ops = [
 [project.scripts]
 fsu-api = "factsynth_ultimate.app:create_app"
 
-[tool.poetry.dependencies]
-pydantic-settings = "*"
-


### PR DESCRIPTION
## Summary
- remove redundant `[tool.poetry.dependencies]` section

## Testing
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_68beb2dae1fc8329a30b2b2d7deedb91