### PR TITLE
chore: pin GitHub workflows to action commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix: { python-version: [ "3.10", "3.11", "3.12" ] }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with: { python-version: ${{ matrix.python-version }} }
-      - uses: actions/cache@v4
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
@@ -23,5 +23,5 @@ jobs:
       - name: Test
         env: { PYTHONPATH: src }
         run: pytest -q --maxfail=1 --disable-warnings --cov=src/factsynth_ultimate --cov-report=xml:coverage.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with: { name: coverage-xml-${{ matrix.python-version }}, path: coverage.xml }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,9 +21,9 @@ jobs:
       matrix:
         language: ['python']
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: github/codeql-action/init@89a24c6ee16ddb44378d0173029da8a64f91a496 # v3
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@89a24c6ee16ddb44378d0173029da8a64f91a496 # v3
+      - uses: github/codeql-action/analyze@89a24c6ee16ddb44378d0173029da8a64f91a496 # v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,8 +11,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with: { python-version: "3.11" }
       - name: Install
         run: |
@@ -62,7 +62,7 @@ PY
           };
           </script></body></html>
           HTML
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with: { path: "./site" }
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -12,14 +12,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       - name: Build release artifacts
         run: bash scripts/build_release.sh
       - name: Upload release assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         with:
           files: |
             release/dist/*

--- a/.github/workflows/zipci.yml
+++ b/.github/workflows/zipci.yml
@@ -18,7 +18,7 @@ jobs:
     name: zipci/intake
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with: { fetch-depth: 0 }
 
       - name: Locate newest ZIP
@@ -32,7 +32,7 @@ jobs:
           echo "ZIP=$FILE"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with: { python-version: '3.x' }
 
       - name: Sanitize ZIP
@@ -41,7 +41,7 @@ jobs:
 
       - name: Load config
         id: cfg
-        uses: mikefarah/yq@v4
+        uses: mikefarah/yq@6251e95af8df3505def48c71f3119836701495d6 # v4
         with:
           cmd: yq -r '.staging_dir // ".zipci_staging"' .zipci.yml
       - name: Prepare staging
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create PR
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ github.token }}
           title: "ZIP Sync → main (#${{ github.run_id }})"
@@ -82,7 +82,7 @@ jobs:
 
       - name: Enable PR automerge
         if: steps.cpr.outputs.pull-request-number != ''
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ github.token }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -95,23 +95,23 @@ jobs:
     outputs:
       status: ${{ steps.status.outputs.result }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           ref: "zipci/${{ github.run_id }}"
           fetch-depth: 0
 
       - name: Setup toolchains
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with: { python-version: '3.x' }
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with: { node-version: 'lts/*', cache: 'npm' }
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with: { go-version: 'stable' }
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
 
       - name: Load commands
         id: cmds
-        uses: mikefarah/yq@v4
+        uses: mikefarah/yq@6251e95af8df3505def48c71f3119836701495d6 # v4
         with:
           cmd: |
             echo "::group::zipci.yml"
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: zipci-logs-${{ github.run_id }}
           path: |
@@ -192,7 +192,7 @@ jobs:
 
       - name: Open failure Issue
         if: needs.validate.result != 'success'
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
         with:
           title: "CI Failure: ${{ github.run_id }}"
           content-filepath: ISSUE_BODY.md


### PR DESCRIPTION
## Summary
- pin GitHub Actions in workflows to specific commit SHAs for reproducibility
- annotate each action with its upstream tag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy'; jax; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68beb2dc52e88329abbbe6a6b3f40157