### PR TITLE
chore: add schemathesis dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest",
     "httpx",
     "uvicorn",
+    "schemathesis",
 ]
 ops = [
     "prometheus-client",


### PR DESCRIPTION
## Summary
- include schemathesis in optional dev dependencies

## Testing
- `pip install -e .[dev,ops]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec179f9c8832980fb054208765836