### PR TITLE
Use parsed IP allowlist and fix type issues

### DIFF
--- a/src/factsynth_ultimate/akpshi/metrics.py
+++ b/src/factsynth_ultimate/akpshi/metrics.py
@@ -1,20 +1,25 @@
 
-import numpy as np
 from typing import Sequence
 
-def rmse(y: Sequence[float], yhat: Sequence[float])->float:
-    y = np.asarray(y, float); yhat = np.asarray(yhat, float)
-    if y.shape != yhat.shape:
-        raise ValueError("y and yhat must have the same shape")
-    return float(np.sqrt(np.mean((y - yhat)**2)))
+import numpy as np
 
-def fcr(num_confirmed: int, total: int)->float:
+
+def rmse(y: Sequence[float], yhat: Sequence[float]) -> float:
+    y_arr = np.asarray(y, dtype=float)
+    yhat_arr = np.asarray(yhat, dtype=float)
+    if y_arr.shape != yhat_arr.shape:
+        raise ValueError("y and yhat must have the same shape")
+    return float(np.sqrt(np.mean((y_arr - yhat_arr) ** 2)))
+
+def fcr(num_confirmed: int, total: int) -> float:
     total = max(int(total), 1)
     num_confirmed = max(int(num_confirmed), 0)
-    return float(num_confirmed/total)
+    return float(num_confirmed / total)
 
-def pfi(level_scores: Sequence[float])->float:
+
+def pfi(level_scores: Sequence[float]) -> float:
     arr = np.asarray(level_scores, float)
-    if arr.size == 0: return 0.0
+    if arr.size == 0:
+        return 0.0
     arr = np.clip(arr, 0.0, 1.0)
     return float(np.mean(arr))

--- a/src/factsynth_ultimate/app.py
+++ b/src/factsynth_ultimate/app.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import time
 from contextlib import suppress
 from typing import Awaitable, Callable
@@ -18,9 +17,9 @@ from .core.metrics import LATENCY, REQUESTS, metrics_bytes, metrics_content_type
 from .core.ratelimit import RateLimitMiddleware
 from .core.request_id import RequestIDMiddleware
 from .core.secrets import read_api_key
-from .core.tracing import try_enable_otel
 from .core.security_headers import SecurityHeadersMiddleware
 from .core.settings import load_settings
+from .core.tracing import try_enable_otel
 
 
 class _MetricsMiddleware(BaseHTTPMiddleware):
@@ -71,7 +70,7 @@ def create_app(
     if settings.ip_allowlist:
         app.add_middleware(
             IPAllowlistMiddleware,
-            cidrs=settings.ip_allowlist.split(","),
+            cidrs=settings.ip_allowlist,
         )
     app.add_middleware(BodySizeLimitMiddleware)
     app.add_middleware(

--- a/src/factsynth_ultimate/core/secrets.py
+++ b/src/factsynth_ultimate/core/secrets.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 try:
     import hvac  # type: ignore[import]
-    from hvac.exceptions import VaultError
 except ImportError:  # pragma: no cover - optional dependency
     hvac = None
 
+if TYPE_CHECKING or hvac is not None:
+    from hvac.exceptions import VaultError
+else:
     class VaultError(Exception):
         pass
 


### PR DESCRIPTION
## Summary
- use pre-parsed `ip_allowlist` when adding the IPAllowlist middleware
- fix mypy failures in secrets and metrics modules

## Testing
- `ruff check src/factsynth_ultimate/app.py src/factsynth_ultimate/akpshi/metrics.py src/factsynth_ultimate/core/secrets.py`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68bec17eea64832990511cc24e64a91e