### PR TITLE
Remove redundant incubation-pack changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## [incubation-pack] - 2025-09-08
-- Додано Incubation Pack: CI релізи, Helm-чарт, OpenAPI контракт-тести, Makefile-таргети.
-- Автоматичне узгодження версій: Docker tag та Helm .Chart.AppVersion = версія з pyproject.toml.
-
-
 ## [1.0.3-incubation-pack] - 2025-09-08
 - Додано Incubation Co‑Dev пакет: GitHub Action, Helm chart, канонічний релізний ZIP, OpenAPI контракт‑тест.
 - Підготовлено Makefile‑таргети release/sbom/checksums/test-contract.


### PR DESCRIPTION
## Summary
- drop outdated `[incubation-pack]` entry from changelog, keeping `1.0.3-incubation-pack` as latest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec17e66bc83298f36e0f8bcc4732f