### PR TITLE
chore(ci): add coverage gate and static analysis jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,42 @@ jobs:
       - name: Test
         env: { PYTHONPATH: src }
         run: pytest -q --maxfail=1 --disable-warnings --cov=src/factsynth_ultimate --cov-report=xml:coverage.xml
+      - name: Check coverage threshold
+        run: |
+          python - <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+          coverage = float(ET.parse('coverage.xml').getroot().get('line-rate')) * 100
+          print(f"Total coverage: {coverage:.2f}%")
+          if coverage < 85:
+              sys.exit("Coverage below 85%")
+          PY
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with: { name: coverage-xml-${{ matrix.python-version }}, path: coverage.xml }
+
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with: { python-version: "3.12" }
+      - name: Install ruff
+        run: |
+          python -m pip install -U pip
+          pip install ruff
+      - name: Ruff
+        run: ruff check .
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with: { python-version: "3.12" }
+      - name: Install mypy
+        run: |
+          python -m pip install -U pip
+          pip install mypy
+          pip install -e .[dev] || pip install -e .
+      - name: Mypy
+        run: mypy src


### PR DESCRIPTION
## Summary
- fail CI when coverage < 85% by parsing `coverage.xml`
- add dedicated `ruff` and `mypy` checks that stop on errors

## Testing
- `mypy src`
- `ruff check .` *(fails: found 53 errors)*
- `pytest -q --maxfail=1 --disable-warnings --cov=src/factsynth_ultimate --cov-report=xml:coverage.xml` *(fails: `schemathesis` has no attribute `from_path`)*


------
https://chatgpt.com/codex/tasks/task_e_68bf021955ac8329b770ca75a3c0ee89