### PR TITLE
refactor pages workflow formatting

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,78 +1,81 @@
 name: Pages (Coverage + OpenAPI + Demo)
 on:
-  push: { branches: [ main ] }
-  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 permissions:
   contents: read
   pages: write
   id-token: write
-concurrency: { group: "pages", cancel-in-progress: true }
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
       - name: Install
         run: |
           python -m pip install -U pip
           pip install -e .[dev] || pip install -e .
       - name: Run tests with coverage
-        env: { PYTHONPATH: src }
+        env:
+          PYTHONPATH: src
         run: |
           pytest -q --maxfail=1 --disable-warnings --cov=src/factsynth_ultimate --cov-report=xml:coverage.xml
           test -f coverage.xml || (echo "coverage.xml not found" && exit 1)
       - name: Prepare site dirs
         run: mkdir -p site site/badges site/openapi
       - name: Copy OpenAPI spec
-        env: { TAG: ${{ github.ref_name }} }
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           if [ -f openapi/openapi.yaml ]; then
             mkdir -p "site/openapi/${TAG}"
             cp openapi/openapi.yaml "site/openapi/${TAG}/openapi.yaml"
           fi
       - name: Generate coverage badge
-        run: |
-          python tools/make_badge.py --xml coverage.xml --out site/badges/coverage.svg || python - <<'PY'
-import xml.etree.ElementTree as ET, pathlib
-rate = float(ET.parse("coverage.xml").getroot().attrib.get("line-rate","0"))*100
-svg=f'<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20"><rect width="80" height="20" fill="#555"/><rect x="80" width="70" height="20" fill="#97CA00"/><g fill="#fff" font-family="DejaVu Sans,Verdana,sans-serif" font-size="11"><text x="40" y="14" text-anchor="middle">coverage</text><text x="115" y="14" text-anchor="middle">{rate:.1f}%</text></g></svg>'
-p=pathlib.Path("site/badges"); p.mkdir(parents=True, exist_ok=True); (p/"coverage.svg").write_text(svg)
-PY
+        run: scripts/generate_coverage_badge.sh
       - name: Publish OpenAPI + Demo
-        env: { TAG: ${{ github.ref_name }} }
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           if [ -f openapi/openapi.yaml ]; then
             python tools/generate_openapi_index.py site/openapi
             cat > "site/openapi/${TAG}/index.html" <<'HTML'
-<!doctype html><html><head><meta charset="utf-8"/>
-<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
-<title>FactSynth API</title></head><body><redoc spec-url="openapi.yaml"></redoc></body></html>
-HTML
+            <!doctype html><html><head><meta charset="utf-8"/>
+            <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+            <title>FactSynth API</title></head><body><redoc spec-url="openapi.yaml"></redoc></body></html>
+            HTML
           fi
           cat > site/index.html <<'HTML'
-<!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>FactSynth — Live Demo</title></head><body>
-<h1>FactSynth — Live Demo</h1><p>API: <code id="apiBase"></code></p>
-<textarea id="prompt" rows="6" cols="80">hello world</textarea><br/>
-<input id="max" type="number" value="5" min="1"/><button id="run">Generate</button>
-<pre id="out"></pre><p>Coverage: <img src="./badges/coverage.svg"/></p><p><a href="./openapi/index.html">OpenAPI Docs</a></p>
-<script>
-function q(n){return new URLSearchParams(location.search).get(n)}
-const API = q('api') || (location.origin.includes('github.io') ? '' : location.origin);
-document.getElementById('apiBase').textContent = API || '(set ?api=https://host)';
-document.getElementById('run').onclick = async ()=>{
-  const prompt=document.getElementById('prompt').value; const max=parseInt(document.getElementById('max').value||'5',10);
-  const out=document.getElementById('out'); out.textContent='...';
-  try{
-    const r=await fetch((API||'')+'/v1/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt,max_tokens:max})});
-    const j=await r.json().catch(async()=>({raw:await r.text()})); out.textContent=JSON.stringify(j,null,2);
-  }catch(e){ out.textContent='Request failed: '+e; }
-};
-</script></body></html>
-HTML
+          <!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+          <title>FactSynth — Live Demo</title></head><body>
+          <h1>FactSynth — Live Demo</h1><p>API: <code id="apiBase"></code></p>
+          <textarea id="prompt" rows="6" cols="80">hello world</textarea><br/>
+          <input id="max" type="number" value="5" min="1"/><button id="run">Generate</button>
+          <pre id="out"></pre><p>Coverage: <img src="./badges/coverage.svg"/></p><p><a href="./openapi/index.html">OpenAPI Docs</a></p>
+          <script>
+          function q(n){return new URLSearchParams(location.search).get(n)}
+          const API = q('api') || (location.origin.includes('github.io') ? '' : location.origin);
+          document.getElementById('apiBase').textContent = API || '(set ?api=https://host)';
+          document.getElementById('run').onclick = async ()=>{
+            const prompt=document.getElementById('prompt').value; const max=parseInt(document.getElementById('max').value||'5',10);
+            const out=document.getElementById('out'); out.textContent='...';
+            try{
+              const r=await fetch((API||'')+'/v1/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt,max_tokens:max})});
+              const j=await r.json().catch(async()=>({raw:await r.text()})); out.textContent=JSON.stringify(j,null,2);
+            }catch(e){ out.textContent='Request failed: '+e; }
+          };
+          </script></body></html>
+          HTML
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
-        with: { path: "./site" }
+        with:
+          path: "./site"
       - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/scripts/generate_coverage_badge.sh
+++ b/scripts/generate_coverage_badge.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python tools/make_badge.py --xml coverage.xml --out site/badges/coverage.svg || python - <<'PY'
+import xml.etree.ElementTree as ET, pathlib
+rate = float(ET.parse("coverage.xml").getroot().attrib.get("line-rate","0"))*100
+svg=f'<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20"><rect width="80" height="20" fill="#555"/><rect x="80" width="70" height="20" fill="#97CA00"/><g fill="#fff" font-family="DejaVu Sans,Verdana,sans-serif" font-size="11"><text x="40" y="14" text-anchor="middle">coverage</text><text x="115" y="14" text-anchor="middle">{rate:.1f}%</text></g></svg>'
+p=pathlib.Path("site/badges"); p.mkdir(parents=True, exist_ok=True); (p/"coverage.svg").write_text(svg)
+PY


### PR DESCRIPTION
## Summary
- expand inline YAML mappings to block style in Pages workflow
- use key-only `workflow_dispatch` trigger
- move coverage badge generation into reusable script

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: {max: 400}}}' .github/workflows/pages.yml`
- `bash -n scripts/generate_coverage_badge.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bf2fa8596c83298a6122a52473f48f