### PR TITLE
Normalize metrics path using route

### DIFF
--- a/src/factsynth_ultimate/app.py
+++ b/src/factsynth_ultimate/app.py
@@ -30,7 +30,8 @@ class _MetricsMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        path = request.url.path
+        route = request.scope.get("route")
+        path = route.path if route else request.url.path
         method = request.method
         start = time.perf_counter()
         response = await call_next(request)


### PR DESCRIPTION
## Summary
- Normalize metrics labels by deriving paths from matched routes when available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd33ef7208329a35773a089abf13b