### PR TITLE
chore: reuse CI coverage in pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,12 +23,11 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -e .[dev] || pip install -e .
-      - name: Run tests with coverage
-        env:
-          PYTHONPATH: src
-        run: |
-          pytest -q --maxfail=1 --disable-warnings --cov=src/factsynth_ultimate --cov-report=xml:coverage.xml
-          test -f coverage.xml || (echo "coverage.xml not found" && exit 1)
+      - name: Download coverage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: coverage-xml-3.11
+          path: .
       - name: Prepare site dirs
         run: mkdir -p site site/badges site/openapi
       - name: Copy OpenAPI spec


### PR DESCRIPTION
## Summary
- reuse coverage.xml produced by CI in Pages workflow
- drop redundant test execution from Pages build

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd33edd44832986dd3239ff011657