### PR TITLE
ci: centralize python setup for lint jobs

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,0 +1,28 @@
+name: Setup Python dependencies
+description: Set up Python, cache pip, and install project dependencies
+inputs:
+  python-version:
+    description: Python version to use
+    required: true
+  extra-packages:
+    description: Optional space-separated list of extra packages to install
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+      with:
+        path: ~/.cache/pip
+        key: pip-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install -U pip
+        pip install -e .[dev] || pip install -e .
+        if [ -n "${{ inputs.extra-packages }}" ]; then
+          pip install ${{ inputs.extra-packages }}
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,18 +80,10 @@ jobs:
     fail-on-error: true
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.12"
-      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-ruff-${{ hashFiles('pyproject.toml') }}
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          pip install ruff
-          pip install -e .[dev] || pip install -e .
+          extra-packages: ruff
       - name: Ruff
         run: ruff check .
 
@@ -100,17 +92,9 @@ jobs:
     fail-on-error: true
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: ./.github/actions/setup-python-deps
         with:
           python-version: "3.12"
-      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-mypy-${{ hashFiles('pyproject.toml') }}
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          pip install mypy
-          pip install -e .[dev] || pip install -e .
+          extra-packages: mypy
       - name: Mypy
         run: mypy src


### PR DESCRIPTION
## Summary
- add `setup-python-deps` composite action to handle Python install, cache and extra deps
- simplify `ruff` and `mypy` jobs to use the new action

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd33fa2cc832989e72d250a4fcb63