### PR TITLE
refactor: use multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
-FROM python:3.11-slim AS base
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim@sha256:316d89b74c4d467565864be703299878ca7a97893ed44ae45f6acba5af09d154 AS build
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
 COPY pyproject.toml README.md LICENSE ./
 RUN pip install -U pip && pip install .[dev,ops]
 COPY src ./src
+
+FROM python:3.11-slim@sha256:316d89b74c4d467565864be703299878ca7a97893ed44ae45f6acba5af09d154
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
 COPY .env.example ./.env
+RUN pip install -U pip && pip install .[ops]
 EXPOSE 8000
 USER 10001
 CMD ["fsu-api"]


### PR DESCRIPTION
## Summary
- use multi-stage Dockerfile with separate build and runtime stages
- pin python:3.11-slim base image to immutable digest

## Testing
- `docker build -t factsynth-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'schemathesis')*

------
https://chatgpt.com/codex/tasks/task_e_68bfd808d9d08329908982768a991984