### PR TITLE
Refactor metrics helpers for clarity

### DIFF
--- a/src/factsynth_ultimate/glrtpm/metrics.py
+++ b/src/factsynth_ultimate/glrtpm/metrics.py
@@ -1,18 +1,53 @@
-
 from typing import Dict, List
 
-def _len(s:str)->int: return len(s or "")
 
-def compute_coherence(*parts:str)->float:
-    L = sum(_len(p) for p in parts) or 1
+def _len(s: str) -> int:
+    """Return length of ``s`` treating ``None`` as empty."""
+    return len(s or "")
+
+
+def compute_coherence(*parts: str) -> float:
+    """Calculate a normalized token uniqueness score.
+
+    Args:
+        *parts: Text segments to compare.
+
+    Returns:
+        float: Uniqueness score scaled to ``[0, 10]``.
+
+    The score is computed by dividing the number of unique tokens by the
+    total length of all parts and scaling by 10.
+    """
+
+    total_len = sum(_len(p) for p in parts) or 1
     uniq_tokens = len(set(" ".join(parts).lower().split()))
-    return round(uniq_tokens / L * 10.0, 4)
+    return round(uniq_tokens / total_len * 10.0, 4)
 
-def cluster_density(nodes: List[str])->float:
+
+def cluster_density(nodes: List[str]) -> float:
+    """Measure density of unique tokens within ``nodes``.
+
+    Args:
+        nodes: List of text nodes.
+
+    Returns:
+        float: Ratio of unique tokens to total token count.
+    """
+
     total = sum(_len(n) for n in nodes) or 1
     uniq = len(set(" ".join(nodes).lower().split()))
     return round(uniq / total, 4)
 
-def role_contribution(chunks: Dict[str,str])->Dict[str,float]:
+
+def role_contribution(chunks: Dict[str, str]) -> Dict[str, float]:
+    """Compute relative contribution of text length for each role.
+
+    Args:
+        chunks: Mapping of role names to their generated text.
+
+    Returns:
+        dict: Proportion of total length for each role.
+    """
+
     total = sum(_len(v) for v in chunks.values()) or 1
-    return {k: round(_len(v)/total, 3) for k,v in chunks.items()}
+    return {k: round(_len(v) / total, 3) for k, v in chunks.items()}


### PR DESCRIPTION
## Summary
- expand metrics helpers into multi-line functions with docstrings
- document intent and return values for coherence, density, and role contribution

## Testing
- `ruff check src/factsynth_ultimate/glrtpm/metrics.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfdc44de048329a51e28d366f291d8