### PR TITLE
Use JSON for meta-projection output

### DIFF
--- a/src/factsynth_ultimate/glrtpm/pipeline.py
+++ b/src/factsynth_ultimate/glrtpm/pipeline.py
@@ -1,9 +1,11 @@
 
+import json
 from dataclasses import dataclass, field
-from typing import List, Dict, Any, Callable
+from typing import Any, Callable, Dict, List
 
-from .roles import Rationalist, Critic, Aesthete, Integrator, Observer
-from .metrics import compute_coherence, cluster_density, role_contribution
+from .metrics import cluster_density, compute_coherence, role_contribution
+from .roles import Aesthete, Critic, Integrator, Observer, Rationalist
+
 
 @dataclass
 class GLRTPMConfig:
@@ -20,7 +22,13 @@ class GLRTPMPipeline:
                 [Rationalist().respond(t), Aesthete().respond(t)]
             ),
             "P": lambda t, res: (
-                f"[Meta-Projection] Nodes: {{'thesis': '{t[:64]}...', 'counter': '{res.get('R', '')[:64]}...'}}"
+                "[Meta-Projection] Nodes: "
+                + json.dumps(
+                    {
+                        "thesis": f"{t[:64]}...",
+                        "counter": f"{res.get('R', '')[:64]}...",
+                    }
+                )
             ),
             "Omega": lambda t, _: Integrator().respond(t)
             + " | "


### PR DESCRIPTION
## Summary
- Import `json` in GLRTPM pipeline
- Emit meta-projection results via `json.dumps` for structured thesis/counter text

## Testing
- `ruff check src/factsynth_ultimate/glrtpm/pipeline.py`
- `mypy src/factsynth_ultimate/glrtpm/pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bff354873483299ed5cd836efdba58