### PR TITLE
actions: stabilize CI, fix ZIPCI env/escaping, simplify Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,40 +7,45 @@ on:
 permissions:
   contents: read
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-      - name: Install
-        run: |
-          python -m pip install -U pip
-          pip install -e .[dev] || pip install -e .
-      - name: Test
-        env:
-          PYTHONPATH: src
-        run: pytest -q --maxfail=1 --disable-warnings --cov=src/factsynth_ultimate --cov-report=xml:coverage.xml
-      - name: Coverage check
-        run: |
-          python - <<'PY'
-          import sys, xml.etree.ElementTree as ET
-          rate = float(ET.parse('coverage.xml').getroot().get('line-rate', 0)) * 100
-          print(f"Coverage: {rate:.2f}%")
-          sys.exit(rate < 85)
-          PY
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: coverage-xml-${{ matrix.python-version }}
-          path: coverage.xml
+    test:
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          python-version: [ "3.10", "3.11", "3.12" ]
+      steps:
+        - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+          with:
+            python-version: ${{ matrix.python-version }}
+        - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+          with:
+            path: ~/.cache/pip
+            key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+        - name: Install
+          run: |
+            python -m pip install -U pip
+            pip install -e .[dev] || pip install -e .
+            pip install -U ruff mypy pytest pytest-cov
+        - name: Ruff
+          run: ruff check . --output-format=github
+        - name: MyPy
+          run: mypy --install-types --non-interactive
+        - name: Test
+          env:
+            PYTHONPATH: src
+          run: pytest -q --maxfail=1 --disable-warnings --cov=src/factsynth_ultimate --cov-report=xml:coverage.xml
+        - name: Coverage check
+          run: |
+            python - <<'PY'
+            import sys, xml.etree.ElementTree as ET
+            rate = float(ET.parse('coverage.xml').getroot().get('line-rate', 0)) * 100
+            print(f"Coverage: {rate:.2f}%")
+            sys.exit(rate < 85)
+            PY
+        - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+          with:
+            name: coverage-xml-${{ matrix.python-version }}
+            path: coverage.xml
 
   container:
     runs-on: ubuntu-latest
@@ -80,27 +85,3 @@ jobs:
       - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
       - name: Sign image
         run: cosign sign --key "${{ secrets.COSIGN_KEY }}" ${{ env.IMAGE_NAME }}
-
-  ruff:
-    runs-on: ubuntu-latest
-    fail-on-error: true
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: ./.github/actions/setup-python-deps
-        with:
-          python-version: "3.12"
-          extra-packages: ruff
-      - name: Ruff
-        run: ruff check .
-
-  mypy:
-    runs-on: ubuntu-latest
-    fail-on-error: true
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: ./.github/actions/setup-python-deps
-        with:
-          python-version: "3.12"
-          extra-packages: mypy
-      - name: Mypy
-        run: mypy src

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,80 +1,33 @@
-name: Pages (Coverage + OpenAPI + Demo)
+name: Pages (OpenAPI)
 on:
   push:
-    branches:
-      - main
+    branches: [ "main" ]
   workflow_dispatch:
 permissions:
   contents: read
   pages: write
   id-token: write
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: true
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          python-version: "3.11"
-      - name: Install
+          node-version: "20"
+      - name: Build ReDoc
         run: |
-          python -m pip install -U pip
-          pip install -e .[dev] || pip install -e .
-      - name: Download coverage artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: coverage-xml-3.11
-          path: .
-      - name: Prepare site dirs
-        run: mkdir -p site site/badges site/openapi
-      - name: Copy OpenAPI spec
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
+          mkdir -p site
           if [ -f openapi/openapi.yaml ]; then
-            mkdir -p "site/openapi/${TAG}"
-            cp openapi/openapi.yaml "site/openapi/${TAG}/openapi.yaml"
+            npx --yes redoc-cli@0.13.23 bundle openapi/openapi.yaml -o site/index.html
+          else
+            echo "<!doctype html><title>No OpenAPI</title><p>No openapi/openapi.yaml</p>" > site/index.html
           fi
-      - name: Generate coverage badge
-        run: scripts/generate_coverage_badge.sh
-      - name: Publish OpenAPI + Demo
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          if [ -f openapi/openapi.yaml ]; then
-            python tools/generate_openapi_index.py site/openapi
-            cat > "site/openapi/${TAG}/index.html" <<'HTML'
-            <!doctype html><html><head><meta charset="utf-8"/>
-            <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
-            <title>FactSynth API</title></head><body><redoc spec-url="openapi.yaml"></redoc></body></html>
-            HTML
-          fi
-          cat > site/index.html <<'HTML'
-          <!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-          <title>FactSynth — Live Demo</title></head><body>
-          <h1>FactSynth — Live Demo</h1><p>API: <code id="apiBase"></code></p>
-          <textarea id="prompt" rows="6" cols="80">hello world</textarea><br/>
-          <input id="max" type="number" value="5" min="1"/><button id="run">Generate</button>
-          <pre id="out"></pre><p>Coverage: <img src="./badges/coverage.svg"/></p><p><a href="./openapi/index.html">OpenAPI Docs</a></p>
-          <script>
-          function q(n){return new URLSearchParams(location.search).get(n)}
-          const API = q('api') || (location.origin.includes('github.io') ? '' : location.origin);
-          document.getElementById('apiBase').textContent = API || '(set ?api=https://host)';
-          document.getElementById('run').onclick = async ()=>{
-            const prompt=document.getElementById('prompt').value; const max=parseInt(document.getElementById('max').value||'5',10);
-            const out=document.getElementById('out'); out.textContent='...';
-            try{
-              const r=await fetch((API||'')+'/v1/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt,max_tokens:max})});
-              const j=await r.json().catch(async()=>({raw:await r.text()})); out.textContent=JSON.stringify(j,null,2);
-            }catch(e){ out.textContent='Request failed: '+e; }
-          };
-          </script></body></html>
-          HTML
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: "./site"
-      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/zipci.yml
+++ b/.github/workflows/zipci.yml
@@ -188,13 +188,14 @@ jobs:
       - name: Prepare Issue body
         if: needs.validate.result != 'success'
         shell: bash
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PR_BRANCH: zipci/${{ github.run_id }}
+          ZIP_NAME: ${{ github.event.head_commit.message || 'ZIP' }}
         run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          PR_BRANCH="zipci/${{ github.run_id }}"
-          ZIP_NAME="$(basename "${{ github.event.head_commit.message || 'ZIP' }}")"
-          sed -e "s|\${{ RUN_URL }}|$RUN_URL|g" \
-              -e "s|\${{ PR_BRANCH }}|$PR_BRANCH|g" \
-              -e "s|\${{ ZIP_NAME }}|$ZIP_NAME|g" .github/ISSUE_TEMPLATE/ci_failure.md > ISSUE_BODY.md
+          sed -e "s|$${{ RUN_URL }}|$RUN_URL|g" \
+              -e "s|$${{ PR_BRANCH }}|$PR_BRANCH|g" \
+              -e "s|$${{ ZIP_NAME }}|$ZIP_NAME|g" .github/ISSUE_TEMPLATE/ci_failure.md > ISSUE_BODY.md
 
       - name: Open failure Issue
         if: needs.validate.result != 'success'


### PR DESCRIPTION
## Summary
- ensure required tooling in CI and remove invalid fail-on-error
- escape ZIPCI tokens via env vars to fix sed
- rebuild Pages workflow to generate ReDoc without coverage artifact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bff9d6f25083298531517173f071ca