### PR TITLE
Fail CI on Ruff errors and require quality job

### DIFF
--- a/.github/scripts/protect_main.json
+++ b/.github/scripts/protect_main.json
@@ -2,8 +2,9 @@
   "required_status_checks": {
     "strict": true,
     "contexts": [
-      "CI / Lint/Types/Tests (py3.11)",
-      "CI / Lint/Types/Tests (py3.12)",
+      "CI / Quality (ruff/mypy)",
+      "CI / PyTest (smoke) (3.11)",
+      "CI / PyTest (smoke) (3.12)",
       "Pages (OpenAPI) / deploy",
       "ZipCI / zip"
     ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           pip install -U ruff mypy
       - name: Ruff
         run: ruff check . --output-format=github
-        continue-on-error: true
+        continue-on-error: false
       - name: MyPy
         run: mypy --install-types --non-interactive || true
         continue-on-error: true


### PR DESCRIPTION
## Summary
- fail the Ruff lint step instead of ignoring errors
- require the quality job in branch protection rules

## Testing
- `ruff check .` *(fails: Found 54 errors)*
- `pytest -q` *(fails: No module named 'schemathesis')*

------
https://chatgpt.com/codex/tasks/task_e_68c0243b682883299a6e136541f40b49