### PR TITLE
refactor: consolidate ISR sim imports

### DIFF
--- a/src/factsynth_ultimate/isr/__init__.py
+++ b/src/factsynth_ultimate/isr/__init__.py
@@ -1,17 +1,9 @@
 from .sim import (
-    ISRParams as ISRParams,
-)
-from .sim import (
-    dominant_freq as dominant_freq,
-)
-from .sim import (
-    estimate_fs as estimate_fs,
-)
-from .sim import (
-    gamma_spectrum as gamma_spectrum,
-)
-from .sim import (
-    simulate_isr as simulate_isr,
+    ISRParams,
+    dominant_freq,
+    estimate_fs,
+    gamma_spectrum,
+    simulate_isr,
 )
 
 __all__ = [


### PR DESCRIPTION
## Summary
- replace multiple ISR sim imports with single grouped import

## Testing
- `ruff check src/factsynth_ultimate/isr/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c0277f2104832985c5dac243789da2