### PR TITLE
style: clean up spacing in choose function

### DIFF
--- a/src/factsynth_ultimate/llm_ifc/arbitrator.py
+++ b/src/factsynth_ultimate/llm_ifc/arbitrator.py
@@ -9,9 +9,9 @@ class Candidate:
     context: float  # [0,1]
     text: str
 
-def choose(cands: List[Candidate], w1: float=0.5, w2: float=0.5)->Dict:
+def choose(cands: List[Candidate], w1: float = 0.5, w2: float = 0.5) -> Dict:
     if not cands:
         return {"winner": None, "score": 0.0, "text": ""}
-    scored = [(c, w1*float(c.quality) + w2*float(c.context)) for c in cands]
+    scored = [(c, w1 * float(c.quality) + w2 * float(c.context)) for c in cands]
     best = max(scored, key=lambda x: x[1])
     return {"winner": best[0].model, "score": float(best[1]), "text": best[0].text}


### PR DESCRIPTION
## Summary
- format choose function in arbitrator to conform to spacing conventions

## Testing
- `ruff check src/factsynth_ultimate/llm_ifc/arbitrator.py`
- `pytest tests/test_llm_ifc.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0277f255483298ec3234a1f7c94f7