### PR TITLE
docs: note main branch protection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,13 @@ Run checks on staged files:
 ```bash
 pre-commit run --files <path/to/file.py>
 ```
+
+## Branch protection
+
+The `main` branch is protected to keep the codebase stable:
+
+- Pushes must come through pull requests.
+- All required status checks must pass before merging.
+- Force pushes are disabled.
+
+Please open a pull request against `main` and ensure all checks succeed.


### PR DESCRIPTION
## Summary
- document branch protection rules for `main` in CONTRIBUTING

## Testing
- `pre-commit run --files CONTRIBUTING.md`
- `pytest` *(fails: assert 25.0 <= 0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c0421d6070832993a6deb2cc62a6da