### PR TITLE
feat: add pluggable scoring backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,24 @@ curl -s -H 'x-api-key: change-me' \
 curl -s http://127.0.0.1:8000/metrics
 ```
 
+### Custom Scoring Backends
+
+`factsynth_ultimate.backends` exposes a pluggable scoring interface.  To add
+your own backend:
+
+```python
+from factsynth_ultimate.backends import ScoreBackend, register_backend, get_backend
+
+class MyBackend(ScoreBackend):
+    def score(self, req):
+        return 0.42
+
+register_backend("my", MyBackend)
+backend = get_backend("my")
+```
+
+The same hook can be used for LLM- or semantic-coverage scoring implementations.
+
 ---
 
 ## Auth & Rate Limits

--- a/src/factsynth_ultimate/backends/__init__.py
+++ b/src/factsynth_ultimate/backends/__init__.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import ScoreBackend
+from .heuristic import HeuristicBackend
+from .llm import LLMBackend
+from .semantic import SemanticBackend
+
+_REGISTRY: Dict[str, Type[ScoreBackend]] = {"heuristic": HeuristicBackend}
+
+
+def register_backend(name: str, backend_cls: Type[ScoreBackend]) -> None:
+    """Register a scoring backend under ``name``."""
+    _REGISTRY[name] = backend_cls
+
+
+def get_backend(name: str | None = None) -> ScoreBackend:
+    """Return an instance of the requested backend.
+
+    If ``name`` is ``None``, the default ``heuristic`` backend is used.
+    """
+    key = name or "heuristic"
+    try:
+        cls = _REGISTRY[key]
+    except KeyError as e:  # pragma: no cover - defensive
+        raise KeyError(f"Unknown scoring backend: {key}") from e
+    return cls()
+
+
+__all__ = [
+    "ScoreBackend",
+    "HeuristicBackend",
+    "LLMBackend",
+    "SemanticBackend",
+    "register_backend",
+    "get_backend",
+]

--- a/src/factsynth_ultimate/backends/base.py
+++ b/src/factsynth_ultimate/backends/base.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..schemas.requests import ScoreReq
+
+
+class ScoreBackend(ABC):
+    """Abstract interface for pluggable scoring backends."""
+
+    @abstractmethod
+    def score(self, req: ScoreReq) -> float:
+        """Return a score in ``[0, 1]`` for ``req``."""
+        raise NotImplementedError

--- a/src/factsynth_ultimate/backends/heuristic.py
+++ b/src/factsynth_ultimate/backends/heuristic.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Dict, Iterable
+
+from .base import ScoreBackend
+from ..schemas.requests import ScoreReq
+
+_WORD_RE = re.compile(r"\w+", re.UNICODE)
+
+
+class HeuristicBackend(ScoreBackend):
+    """Default heuristic scoring backend."""
+
+    def _text_stats(self, text: str) -> Dict[str, float]:
+        n = len(text)
+        if n == 0:
+            return {
+                "len": 0,
+                "uniq_ratio": 0.0,
+                "alpha_ratio": 0.0,
+                "digit_ratio": 0.0,
+                "whitespace_ratio": 0.0,
+                "entropy": 0.0,
+            }
+        uniq_ratio = len(set(text)) / n
+        alpha = sum(ch.isalpha() for ch in text) / n
+        digit = sum(ch.isdigit() for ch in text) / n
+        space = sum(ch.isspace() for ch in text) / n
+        cnt = Counter(text)
+        probs = [c / n for c in cnt.values()]
+        entropy = -sum(p * math.log(p, 2) for p in probs if p > 0)
+        return {
+            "len": n,
+            "uniq_ratio": uniq_ratio,
+            "alpha_ratio": alpha,
+            "digit_ratio": digit,
+            "whitespace_ratio": space,
+            "entropy": entropy,
+        }
+
+    def _coverage(self, text: str, targets: Iterable[str]) -> float:
+        if not targets:
+            return 0.0
+        words = set(_WORD_RE.findall(text.lower()))
+        toks = [t.lower() for t in targets if t]
+        if not toks:
+            return 0.0
+        found = sum(1 for t in toks if t in words)
+        return found / len(toks)
+
+    def score(self, req: ScoreReq) -> float:
+        stats = self._text_stats(req.text)
+        cov = self._coverage(req.text, req.targets or [])
+        length_sat = min(1.0, stats["len"] / 500.0)
+        alpha = stats["alpha_ratio"]
+        ent = min(1.0, stats["entropy"] / 8.0)
+        score = 0.4 * cov + 0.3 * length_sat + 0.2 * alpha + 0.1 * ent
+        return round(float(score), 4)

--- a/src/factsynth_ultimate/backends/llm.py
+++ b/src/factsynth_ultimate/backends/llm.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .base import ScoreBackend
+from ..schemas.requests import ScoreReq
+
+
+class LLMBackend(ScoreBackend):
+    """Placeholder backend that could score using an LLM."""
+
+    def score(self, req: ScoreReq) -> float:  # pragma: no cover - example stub
+        raise NotImplementedError("LLM backend not implemented")

--- a/src/factsynth_ultimate/backends/semantic.py
+++ b/src/factsynth_ultimate/backends/semantic.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .base import ScoreBackend
+from ..schemas.requests import ScoreReq
+
+
+class SemanticBackend(ScoreBackend):
+    """Placeholder backend for semantic coverage scoring."""
+
+    def score(self, req: ScoreReq) -> float:  # pragma: no cover - example stub
+        raise NotImplementedError("Semantic backend not implemented")

--- a/src/factsynth_ultimate/services/runtime.py
+++ b/src/factsynth_ultimate/services/runtime.py
@@ -1,83 +1,28 @@
 from __future__ import annotations
 
-import math
 import re
 import time
-from collections import Counter
-from typing import Any, Dict, Iterable
+from typing import Any, Dict
 
+from ..backends import get_backend
 from ..core.metrics import SCORING_TIME
 from ..schemas.requests import ScoreReq
 
 _WORD_RE = re.compile(r"\w+", re.UNICODE)
 
-def _text_stats(text: str) -> Dict[str, float]:
-    """Compute character-based metrics for *text*.
-
-    Returns a dictionary with:
-
-    - ``len``: total number of characters.
-    - ``uniq_ratio``: proportion of unique characters.
-    - ``alpha_ratio``: fraction of alphabetic characters.
-    - ``digit_ratio``: fraction of digit characters.
-    - ``whitespace_ratio``: fraction of whitespace characters.
-    - ``entropy``: Shannon entropy of character distribution in bits.
-    """
-    n = len(text)
-    if n == 0:
-        return {
-            "len": 0,
-            "uniq_ratio": 0.0,
-            "alpha_ratio": 0.0,
-            "digit_ratio": 0.0,
-            "whitespace_ratio": 0.0,
-            "entropy": 0.0,
-        }
-    uniq_ratio = len(set(text)) / n
-    alpha = sum(ch.isalpha() for ch in text) / n
-    digit = sum(ch.isdigit() for ch in text) / n
-    space = sum(ch.isspace() for ch in text) / n
-    cnt = Counter(text)
-    probs = [c / n for c in cnt.values()]
-    entropy = -sum(p * math.log(p, 2) for p in probs if p > 0)
-    return {
-        "len": n,
-        "uniq_ratio": uniq_ratio,
-        "alpha_ratio": alpha,
-        "digit_ratio": digit,
-        "whitespace_ratio": space,
-        "entropy": entropy,
-    }
 
 def reflect_intent(intent: str, length: int) -> str:
-    intent = re.sub(r"\s+"," ", intent).strip()
-    return intent[:max(0,length)]
+    intent = re.sub(r"\s+", " ", intent).strip()
+    return intent[: max(0, length)]
 
-def _coverage(text: str, targets: Iterable[str]) -> float:
-    if not targets:
-        return 0.0
-    words = set(_WORD_RE.findall(text.lower()))
-    toks = [t.lower() for t in targets if t]
-    if not toks:
-        return 0.0
-    found = sum(1 for t in toks if t in words)
-    return found / len(toks)
 
-def _score_impl(req: ScoreReq) -> float:
-    s = _text_stats(req.text)
-    cov = _coverage(req.text, req.targets or [])
-    length_sat = min(1.0, s["len"]/500.0)
-    alpha = s["alpha_ratio"]
-    ent = min(1.0, s["entropy"]/8.0)
-    score = 0.4*cov + 0.3*length_sat + 0.2*alpha + 0.1*ent
-    return round(float(score),4)
-
-def score_payload(payload: Dict[str, Any]) -> float:
+def score_payload(payload: Dict[str, Any], backend: str | None = None) -> float:
     req = ScoreReq(**(payload or {}))
     t0 = time.perf_counter()
-    val = _score_impl(req)
+    val = get_backend(backend).score(req)
     SCORING_TIME.observe(max(0.0, time.perf_counter() - t0))
     return val
+
 
 def tokenize_preview(text: str, max_tokens: int = 256) -> list[str]:
     toks = _WORD_RE.findall(text)


### PR DESCRIPTION
## Summary
- add abstract `ScoreBackend` interface and registry
- refactor heuristic scoring into `HeuristicBackend`
- expose hooks for LLM or semantic scoring backends
- document how to register a custom backend

## Testing
- `pytest` (fails: tests/test_isr.py::test_isr_shapes_and_peak)


------
https://chatgpt.com/codex/tasks/task_e_68c0421e78f88329abdcff455f04c09d