### PR TITLE
feat: add OIDC JWT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Secure, observable **FastAPI** service for intent reflection, scoring, extractiv
 
 ## Features
 
-* **API-key auth** via `x-api-key` header (skips `/v1/healthz`, `/metrics`, `/v1/version`).
+* **Auth** via `x-api-key` header or JWT/OIDC Bearer token (skips `/v1/healthz`, `/metrics`, `/v1/version`).
 * **Rate limiting** (default 120 req/min) with `X-RateLimit-*` headers.
 * **SSE & WebSocket streaming** for token-like updates.
 * **Extractive generation**: `title`, `summary`, `keywords` from input text.
@@ -156,7 +156,8 @@ curl -s http://127.0.0.1:8000/metrics
 ## Auth & Rate Limits
 
 * API key sources: `API_KEY_FILE` → Vault → `API_KEY` → default `change-me` (dev only)
-* Auth: `x-api-key: <your-secret>`
+* Auth: `x-api-key: <your-secret>` or `Authorization: Bearer <JWT>`
+  * JWT validation uses `OIDC_JWKS_URL`, `OIDC_AUDIENCE` and `OIDC_ISSUER`.
 * Default skip list (no auth): `/v1/healthz`, `/metrics`, `/v1/version`
 * Rate limit: `RATE_LIMIT_PER_MIN` (default **120**) per API key / client IP
 * Response headers:
@@ -225,6 +226,7 @@ Environment variables (examples):
 * `API_KEY` or **file** via `API_KEY_FILE`
 * `AUTH_HEADER_NAME` (default `x-api-key`)
 * `SKIP_AUTH_PATHS` (CSV; default `/v1/healthz,/metrics,/v1/version`)
+* `OIDC_JWKS_URL`, `OIDC_AUDIENCE`, `OIDC_ISSUER` for JWT auth
 * `CORS_ALLOW_ORIGINS` (CSV; default `*` in dev)
 * `HTTPS_REDIRECT` = `1` to force HTTPS
 * `TRUSTED_HOSTS` (CSV; prod only)
@@ -303,7 +305,6 @@ pytest -q --cov=src --cov-report=term-missing
 
 * Pluggable scoring backends (LLM/semantic coverage)
 * Rich Web UI (admin + live metrics)
-* JWT/OIDC alternative auth
 * Distributed cache (Redis) for heavy pipelines
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "httpx",
+    "python-jose[cryptography]",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "prometheus-client",

--- a/src/factsynth_ultimate/app.py
+++ b/src/factsynth_ultimate/app.py
@@ -69,23 +69,22 @@ def create_app(
     app.add_middleware(RequestIDMiddleware)
     app.add_middleware(SecurityHeadersMiddleware, hsts=settings.https_redirect)
     if settings.ip_allowlist:
-        app.add_middleware(
-            IPAllowlistMiddleware, cidrs=settings.ip_allowlist
-        )
+        app.add_middleware(IPAllowlistMiddleware, cidrs=settings.ip_allowlist)
     app.add_middleware(BodySizeLimitMiddleware)
     app.add_middleware(
         APIKeyAuthMiddleware,
         api_key=read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY"),
         header_name=settings.auth_header_name,
         skip=tuple(settings.skip_auth_paths),
+        jwks_url=settings.oidc_jwks_url,
+        audience=settings.oidc_audience,
+        issuer=settings.oidc_issuer,
     )
     app.add_middleware(
         RateLimitMiddleware,
         per_minute=settings.rate_limit_per_minute,
         key_header=settings.auth_header_name,
-        bucket_ttl=bucket_ttl
-        if bucket_ttl is not None
-        else settings.rate_limit_bucket_ttl,
+        bucket_ttl=bucket_ttl if bucket_ttl is not None else settings.rate_limit_bucket_ttl,
         cleanup_interval=cleanup_interval
         if cleanup_interval is not None
         else settings.rate_limit_cleanup_interval,

--- a/src/factsynth_ultimate/core/auth.py
+++ b/src/factsynth_ultimate/core/auth.py
@@ -1,17 +1,69 @@
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from typing import Any, Iterable
 
-from fastapi import Request
+import httpx
+from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import jwt
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from ..i18n import choose_language, translate
+from .settings import load_settings
+
+
+async def _verify_jwt(
+    token: str,
+    jwks_url: str | None,
+    audience: str | None,
+    issuer: str | None,
+) -> dict[str, Any]:
+    """Decode a JWT using a remote JWKS."""
+    if not jwks_url:
+        raise ValueError("jwks url not configured")
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        jwks = (await client.get(jwks_url)).json()
+    header = jwt.get_unverified_header(token)
+    key_data = next(
+        (k for k in jwks.get("keys", []) if k.get("kid") == header.get("kid")),
+        None,
+    )
+    if not key_data:
+        raise ValueError("key not found")
+    return jwt.decode(
+        token,
+        key_data,
+        algorithms=[key_data.get("alg", header.get("alg"))],
+        audience=audience,
+        issuer=issuer,
+    )
+
+
+_bearer = HTTPBearer(auto_error=False)
+
+
+async def get_jwt_claims(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
+) -> dict[str, Any]:
+    """Return JWT claims if a Bearer token is supplied."""
+    if credentials is None:
+        return {}
+    settings = load_settings()
+    try:
+        return await _verify_jwt(
+            credentials.credentials,
+            settings.oidc_jwks_url,
+            settings.oidc_audience,
+            settings.oidc_issuer,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
 
 
 class APIKeyAuthMiddleware(BaseHTTPMiddleware):
-    """Header-based API key auth."""
+    """Authenticate via API key or JWT bearer token."""
 
     def __init__(
         self,
@@ -19,10 +71,16 @@ class APIKeyAuthMiddleware(BaseHTTPMiddleware):
         api_key: str,
         header_name: str = "x-api-key",
         skip: Iterable[str] = ("/v1/healthz", "/metrics"),
+        jwks_url: str | None = None,
+        audience: str | None = None,
+        issuer: str | None = None,
     ):
         super().__init__(app)
         self.api_key = api_key
         self.header_name = header_name
+        self.jwks_url = jwks_url
+        self.audience = audience
+        self.issuer = issuer
         self.skip_exact: set[str] = set()
         patterns = []
         for s in skip:
@@ -39,6 +97,14 @@ class APIKeyAuthMiddleware(BaseHTTPMiddleware):
         provided = request.headers.get(self.header_name)
         if self.api_key and provided == self.api_key:
             return await call_next(request)
+        authz = request.headers.get("authorization")
+        if authz and authz.lower().startswith("bearer "):
+            token = authz.split(" ", 1)[1]
+            try:
+                await _verify_jwt(token, self.jwks_url, self.audience, self.issuer)
+                return await call_next(request)
+            except Exception:  # noqa: BLE001
+                pass
         lang = choose_language(request)
         title = translate(lang, "unauthorized")
         return JSONResponse(

--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -17,12 +17,17 @@ class Settings(BaseSettings):
     skip_auth_paths: list[str] = Field(
         default_factory=lambda: ["/v1/healthz", "/metrics"], env="SKIP_AUTH_PATHS"
     )
+    oidc_jwks_url: str | None = Field(default=None, env="OIDC_JWKS_URL")
+    oidc_audience: str | None = Field(default=None, env="OIDC_AUDIENCE")
+    oidc_issuer: str | None = Field(default=None, env="OIDC_ISSUER")
     rate_limit_per_minute: int = Field(default=120, env="RATE_LIMIT_PER_MINUTE")
     rate_limit_bucket_ttl: float = Field(default=300.0, env="RATE_LIMIT_BUCKET_TTL")
     rate_limit_cleanup_interval: float = Field(default=60.0, env="RATE_LIMIT_CLEANUP_INTERVAL")
     health_tcp_checks: list[str] = Field(default_factory=list, env="HEALTH_TCP_CHECKS")
 
-    @field_validator("cors_allow_origins", "skip_auth_paths", "health_tcp_checks", "ip_allowlist", mode="before")
+    @field_validator(
+        "cors_allow_origins", "skip_auth_paths", "health_tcp_checks", "ip_allowlist", mode="before"
+    )
     @classmethod
     def _split_csv(cls, value: str | list[str]) -> list[str]:
         if isinstance(value, str):
@@ -34,4 +39,3 @@ class Settings(BaseSettings):
 
 def load_settings() -> Settings:
     return Settings()
-

--- a/tests/test_score_and_auth.py
+++ b/tests/test_score_and_auth.py
@@ -2,15 +2,18 @@ import os
 from http import HTTPStatus
 from unittest.mock import patch
 
+import httpx
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi.testclient import TestClient
+from jose import jwt
+from jose.utils import base64url_encode
 
 from factsynth_ultimate.app import create_app
 
 
 def test_auth_required() -> None:
-    with patch.dict(os.environ, {"API_KEY": "secret"}), TestClient(
-        create_app()
-    ) as client:
+    with patch.dict(os.environ, {"API_KEY": "secret"}), TestClient(create_app()) as client:
         url = "/v1/score"
         assert client.post(url, json={"text": "x"}).status_code == HTTPStatus.UNAUTHORIZED
         assert (
@@ -20,9 +23,7 @@ def test_auth_required() -> None:
 
 
 def test_score_values() -> None:
-    with patch.dict(os.environ, {"API_KEY": "secret"}), TestClient(
-        create_app()
-    ) as client:
+    with patch.dict(os.environ, {"API_KEY": "secret"}), TestClient(create_app()) as client:
         r = client.post(
             "/v1/score",
             headers={"x-api-key": "secret"},
@@ -31,3 +32,56 @@ def test_score_values() -> None:
         assert r.status_code == HTTPStatus.OK
         s = r.json()["score"]
         assert 0.0 <= s <= 1.0
+
+
+def test_jwt_auth(monkeypatch) -> None:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    numbers = key.public_key().public_numbers()
+    n = base64url_encode(numbers.n.to_bytes((numbers.n.bit_length() + 7) // 8, "big")).decode()
+    e = base64url_encode(numbers.e.to_bytes((numbers.e.bit_length() + 7) // 8, "big")).decode()
+    jwks = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "kid": "test",
+                "use": "sig",
+                "alg": "RS256",
+                "n": n,
+                "e": e,
+            }
+        ]
+    }
+
+    token = jwt.encode(
+        {"sub": "alice", "aud": "aud", "iss": "iss"},
+        priv,
+        algorithm="RS256",
+        headers={"kid": "test"},
+    )
+
+    async def fake_get(self, url, *args, **kwargs):  # noqa: D401
+        class Resp:
+            def json(self_inner):
+                return jwks
+
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    env = {
+        "API_KEY": "secret",
+        "OIDC_JWKS_URL": "https://example/jwks",
+        "OIDC_AUDIENCE": "aud",
+        "OIDC_ISSUER": "iss",
+    }
+    with patch.dict(os.environ, env), TestClient(create_app()) as client:
+        r = client.post(
+            "/v1/score",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"text": "hello"},
+        )
+        assert r.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Summary
- support JWT/OIDC bearer tokens alongside API keys
- inject decoded JWT claims into FastAPI routes
- document and test the new auth flow

## Testing
- `pre-commit run --files pyproject.toml src/factsynth_ultimate/core/settings.py src/factsynth_ultimate/core/auth.py src/factsynth_ultimate/app.py src/factsynth_ultimate/api/routers.py tests/test_score_and_auth.py README.md` *(fails: tests/test_isr.py::test_isr_shapes_and_peak)*
- `pytest tests/test_score_and_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0421db9288329904a0ca124ac790f