### PR TITLE
feat: add optional redis caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Secure, observable **FastAPI** service for intent reflection, scoring, extractiv
 * **Problem+JSON** structured errors.
 * **Prometheus metrics** + **JSON logs**; optional OpenTelemetry.
 * **HSTS/CSP** security headers; body size limit; optional IP allowlist.
+* Optional Redis caching for pipeline results.
 
 ---
 
@@ -47,7 +48,7 @@ Secure, observable **FastAPI** service for intent reflection, scoring, extractiv
 
 ```bash
 python -m venv .venv && . .venv/bin/activate
-pip install -U pip && pip install -e .[dev,ops]
+pip install -U pip && pip install -e .[dev,ops,cache]
 export API_KEY=change-me        # use secret file or Vault in prod
 uvicorn factsynth_ultimate.app:app --host 0.0.0.0 --port 8000
 ```
@@ -232,6 +233,10 @@ Environment variables (examples):
 * `MAX_BODY_BYTES` (default `2000000`)
 * `RATE_LIMIT_PER_MIN` (default `120`)
 * `HEALTH_TCP_CHECKS` (CSV like `127.0.0.1:5432,[::1]:6379`)
+* `REDIS_URL` to enable caching (e.g. `redis://localhost:6379/0`)
+* `CACHE_TTL` (default `300`) cache expiration in seconds
+
+Caching falls back to an in-memory store if `REDIS_URL` is unset.
 
 Vault support (optional): set `VAULT_ADDR`, `VAULT_TOKEN`, `VAULT_PATH` (reads `API_KEY`).
 

--- a/README_UA.md
+++ b/README_UA.md
@@ -36,6 +36,7 @@
 * **Структуровані помилки** у форматі Problem+JSON.
 * **Метрики Prometheus** + **JSON-логи**; за бажанням OpenTelemetry.
 * **HSTS/CSP** заголовки безпеки; обмеження розміру тіла; необов'язковий список дозволених IP.
+* Необов'язкове кешування в Redis для результатів конвеєра.
 
 ---
 
@@ -43,7 +44,7 @@
 
 ```bash
 python -m venv .venv && . .venv/bin/activate
-pip install -U pip && pip install -e .[dev,ops]
+pip install -U pip && pip install -e .[dev,ops,cache]
 export API_KEY=change-me        # у продакшені використайте секрет або Vault
 uvicorn factsynth_ultimate.app:app --host 0.0.0.0 --port 8000
 ```
@@ -143,7 +144,10 @@ curl -s -H 'x-api-key: change-me' \
 
 ## Конфігурація
 
-Змінні середовища: `API_KEY`, `RATE_LIMIT_PER_MINUTE`, `BODY_MAX_BYTES`, `IP_ALLOWLIST`, тощо.
+Змінні середовища: `API_KEY`, `RATE_LIMIT_PER_MINUTE`, `BODY_MAX_BYTES`, `IP_ALLOWLIST`,
+`REDIS_URL` (вмикає кеш) та `CACHE_TTL` (за замовчуванням 300 с), тощо.
+
+Якщо `REDIS_URL` не встановлено, використовується простий кеш у пам'яті.
 
 ---
 

--- a/pyproject.append.all.toml
+++ b/pyproject.append.all.toml
@@ -10,6 +10,9 @@ isr = [
     "diffrax>=0.5.0",
     "typer>=0.12.0"
 ]
+cache = [
+    "redis>=5.0",
+]
 
 [project.scripts]
 fsu-glrtpm = "factsynth_ultimate.glrtpm.pipeline:GLRTPMPipeline"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ isr = [
 numpy = [
     "numpy",
 ]
+cache = [
+    "redis>=5.0",
+]
 
 [project.scripts]
 fsu-api = "factsynth_ultimate.app:create_app"

--- a/src/factsynth_ultimate/core/cache.py
+++ b/src/factsynth_ultimate/core/cache.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .settings import load_settings
+
+try:  # pragma: no cover - optional dependency
+    import redis  # type: ignore
+except Exception:  # pragma: no cover
+    redis = None  # type: ignore
+
+
+class Cache:
+    """Simple cache that can use Redis if configured."""
+
+    def __init__(self, url: str | None, ttl: int) -> None:
+        self.ttl = ttl
+        if url and redis is not None:
+            self._redis = redis.Redis.from_url(url)
+            self._store: dict[str, Any] | None = None
+        else:
+            self._redis = None
+            self._store = {}
+
+    def get(self, key: str) -> Any | None:
+        if self._redis is not None:
+            value = self._redis.get(key)
+            if value is not None:
+                return json.loads(value)
+            return None
+        return self._store.get(key) if self._store is not None else None
+
+    def set(self, key: str, value: Any) -> None:
+        if self._redis is not None:
+            self._redis.setex(key, self.ttl, json.dumps(value))
+        elif self._store is not None:
+            self._store[key] = value
+
+    def clear(self) -> None:
+        if self._redis is not None:
+            self._redis.flushdb()
+        elif self._store is not None:
+            self._store.clear()
+
+
+_cache: Cache | None = None
+
+
+def get_cache() -> Cache:
+    """Return a singleton cache instance configured from settings."""
+    global _cache
+    if _cache is None:
+        settings = load_settings()
+        _cache = Cache(settings.redis_url, settings.cache_ttl)
+    return _cache

--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -21,6 +21,8 @@ class Settings(BaseSettings):
     rate_limit_bucket_ttl: float = Field(default=300.0, env="RATE_LIMIT_BUCKET_TTL")
     rate_limit_cleanup_interval: float = Field(default=60.0, env="RATE_LIMIT_CLEANUP_INTERVAL")
     health_tcp_checks: list[str] = Field(default_factory=list, env="HEALTH_TCP_CHECKS")
+    redis_url: str | None = Field(default=None, env="REDIS_URL")
+    cache_ttl: int = Field(default=300, env="CACHE_TTL")
 
     @field_validator("cors_allow_origins", "skip_auth_paths", "health_tcp_checks", "ip_allowlist", mode="before")
     @classmethod

--- a/tests/test_glrtpm.py
+++ b/tests/test_glrtpm.py
@@ -1,4 +1,5 @@
 from factsynth_ultimate.glrtpm.pipeline import GLRTPMPipeline
+from factsynth_ultimate.core.cache import get_cache
 
 
 def test_glrtpm_roundtrip():
@@ -6,3 +7,14 @@ def test_glrtpm_roundtrip():
     assert set(["R","I","P","Omega","metrics"]).issubset(out.keys())
     m = out["metrics"]
     assert "coherence" in m and "density" in m and "roles" in m
+
+
+def test_glrtpm_cache():
+    thesis = "Caching thesis"
+    cache = get_cache()
+    cache.clear()
+    pipeline = GLRTPMPipeline()
+    first = pipeline.run(thesis)
+    assert cache.get(f"glrtpm:{thesis}") == first
+    second = pipeline.run(thesis)
+    assert second == first


### PR DESCRIPTION
## Summary
- add optional `redis` dependency and config knobs for cache TTL and connection
- introduce cache module with Redis backend and in-memory fallback
- cache GLRTPM pipeline results and document usage

## Testing
- `pytest -q` *(fails: test_isr_shapes_and_peak - assert 25.0 <= 0.0)*


------
https://chatgpt.com/codex/tasks/task_e_68c0421f32bc83298a7127ef02c8cb5a