### PR TITLE
docs: mention ajv prerequisites and warn if missing

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -9,6 +9,8 @@ cd prompts/scripts
 ./quickstart.sh
 ```
 
+Перед запуском переконайтесь, що встановлено Node.js та утиліта `ajv` з пакета `ajv-cli` (`npm i -g ajv-cli`).
+
 Скрипт:
 
 1. Підкаже встановити `FACTSYNTH_API_KEY`.
@@ -29,6 +31,7 @@ cd prompts/scripts
 
 * Цільова модель: **GPT-5 Thinking** або новіша reasoning-модель.
 * Ключ API: `FACTSYNTH_API_KEY` (передається як `x-api-key`).
+* Node.js 18+ і утиліта `ajv` з пакета `ajv-cli` для валідації схем.
 * Відповіді сервера перевіряються локально за JSON-схемами.
 
 ## Ліцензія

--- a/prompts/scripts/quickstart.sh
+++ b/prompts/scripts/quickstart.sh
@@ -29,8 +29,12 @@ curl -fsS -H "${HDR_AUTH[@]}" -H 'content-type: application/json' \
 
 echo "-- validate schemas"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-"${DIR}/scripts/validate.sh" /tmp/generate.json "${DIR}/SCHEMAS/generate.output.schema.json"
-"${DIR}/scripts/validate.sh" /tmp/score.json "${DIR}/SCHEMAS/score.output.schema.json"
+if command -v ajv >/dev/null; then
+  "${DIR}/scripts/validate.sh" /tmp/generate.json "${DIR}/SCHEMAS/generate.output.schema.json"
+  "${DIR}/scripts/validate.sh" /tmp/score.json "${DIR}/SCHEMAS/score.output.schema.json"
+else
+  echo "Warning: ajv-cli not found, skipping schema validation." >&2
+fi
 
 echo "-- compute checksums"
 "${DIR}/scripts/checksums.sh" "${DIR}"


### PR DESCRIPTION
## Summary
- document Node.js and `ajv-cli` prerequisites for `quickstart.sh`
- skip schema validation in `quickstart.sh` when `ajv` is not installed

## Testing
- `pre-commit run --files prompts/README.md prompts/scripts/quickstart.sh`
- `bash -n prompts/scripts/quickstart.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c085094b088329a4c4775480d68a4e