### PR TITLE
Use integer type for elapsed_ms in meta schema

### DIFF
--- a/prompts/SCHEMAS/meta.schema.json
+++ b/prompts/SCHEMAS/meta.schema.json
@@ -5,7 +5,7 @@
   "properties":{
     "tool":{"type":"string"},
     "trace_id":{"type":"string"},
-    "elapsed_ms":{"type":"number","minimum":0}
+    "elapsed_ms":{"type":"integer","minimum":0}
   },
   "required":["tool"],
   "additionalProperties":true


### PR DESCRIPTION
## Summary
- use integer instead of number for meta.elapsed_ms

## Testing
- `python - <<'PY'
import json, jsonschema, pathlib
base = pathlib.Path('prompts/SCHEMAS').resolve()
meta = json.loads((base / 'meta.schema.json').read_text())
store = {str((base / 'meta.schema.json').resolve().as_uri()): meta}
for name in ['generate.output.schema.json','score.output.schema.json','stream.event.schema.json','intent_reflector.output.schema.json']:
    schema_path = base / name
    schema = json.loads(schema_path.read_text())
    resolver = jsonschema.RefResolver(base_uri=str(base.as_uri()+'/'), referrer=schema, store=store)
    jsonschema.Draft202012Validator.check_schema(schema)
    jsonschema.Draft202012Validator(schema, resolver=resolver)
print('validated all schemas')
PY`
- `pytest` *(fails: tests/test_isr.py::test_isr_shapes_and_peak - assert 25.0 <= 0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c0850ad4fc8329a492b83423e43ba1