### PR TITLE
docs: add test setup script and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,11 +279,31 @@ helm upgrade --install factsynth oci://ghcr.io/<owner>/charts/factsynth \
 ---
 
 ## Testing
+### Test Setup
 
-Before running tests, install the development dependencies:
+The test suite requires the following packages:
+
+* `pytest`
+* `pytest-cov`
+* `httpx`
+* `uvicorn`
+* `schemathesis`
+* `websockets`
+* `jax`
+* `diffrax`
+* `numpy`
+
+Install them via extras or the helper script:
 
 ```bash
-pip install -e .[dev]
+pip install -e .[dev,isr,numpy]
+# or
+./scripts/setup-tests.sh
+```
+
+### Running Tests
+
+```bash
 pytest -q
 pytest -q --cov=src --cov-report=term-missing
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dev = [
     "httpx",
     "uvicorn",
     "schemathesis",  # API contract testing
+    "websockets",  # WebSocket test client
+    "pytest-cov",  # coverage plugin
 ]
 ops = [
     "prometheus-client",

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pip install -U pip
+pip install -e .[dev,isr,numpy]
+


### PR DESCRIPTION
## Summary
- include websockets and pytest-cov in dev dependencies
- document test setup and provide setup-tests.sh helper

## Testing
- `./scripts/setup-tests.sh`
- `pytest -q` *(fails: test_isr_shapes_and_peak)*

------
https://chatgpt.com/codex/tasks/task_e_68c08bf951d48329a9b05dce13b39c53