### PR TITLE
refactor: structure factsynth judge golden set

### DIFF
--- a/prompts/factsynth_judge/GOLDEN_12_TESTSET.json
+++ b/prompts/factsynth_judge/GOLDEN_12_TESTSET.json
@@ -1,14 +1,14 @@
 [
-  "Classification: Decide supported/refuted on a single factual claim with clear span.",
-  "Extraction: Normalize units (miles\u2194km) and verify numeric claim.",
-  "Transformation: Compute year difference from two dates in context.",
-  "Multi-step Reasoning: Join two non-adjacent spans to validate a conditional.",
-  "Coding: Given pseudo-CSV in context, verify 'sum(column)=X'.",
-  "Debugging: Context includes off-by-one example; model must correct it.",
-  "Planning: Identify the minimal 2 follow-up facts needed (`EVIDENCE_GAP`).",
-  "Long-form Writing: Provide rationale but keep `VERDICT` schema strict.",
-  "Summarization: Ensure summary does not introduce new facts (audit check).",
-  "Translation/Localization: Verify date formats \"05/07/2021\" with locale hint.",
-  "Data/Math: Percentage change computed from base and new value in context.",
-  "Tool-Use & Safety/Refusal: Context lacks evidence; must return `NOT_PROVABLE`."
+  {"id":1,"context":"","question":"Classification: Decide supported/refuted on a single factual claim with clear span.","expected":""},
+  {"id":2,"context":"","question":"Extraction: Normalize units (miles\u2194km) and verify numeric claim.","expected":""},
+  {"id":3,"context":"","question":"Transformation: Compute year difference from two dates in context.","expected":""},
+  {"id":4,"context":"","question":"Multi-step Reasoning: Join two non-adjacent spans to validate a conditional.","expected":""},
+  {"id":5,"context":"","question":"Coding: Given pseudo-CSV in context, verify 'sum(column)=X'.","expected":""},
+  {"id":6,"context":"","question":"Debugging: Context includes off-by-one example; model must correct it.","expected":""},
+  {"id":7,"context":"","question":"Planning: Identify the minimal 2 follow-up facts needed (`EVIDENCE_GAP`).","expected":""},
+  {"id":8,"context":"","question":"Long-form Writing: Provide rationale but keep `VERDICT` schema strict.","expected":""},
+  {"id":9,"context":"","question":"Summarization: Ensure summary does not introduce new facts (audit check).","expected":""},
+  {"id":10,"context":"","question":"Translation/Localization: Verify date formats \"05/07/2021\" with locale hint.","expected":""},
+  {"id":11,"context":"","question":"Data/Math: Percentage change computed from base and new value in context.","expected":""},
+  {"id":12,"context":"","question":"Tool-Use & Safety/Refusal: Context lacks evidence; must return `NOT_PROVABLE`.","expected":""}
 ]

--- a/prompts/factsynth_judge/SHASUMS256.txt
+++ b/prompts/factsynth_judge/SHASUMS256.txt
@@ -3,7 +3,7 @@
 4c0572c77add21012db1e9aa5b2cecf33e4b3263bb77a6c41844b908457c4a3a  ./FEW_SHOTS/date_offset_trap.md
 f462cee90fab5efad3b42f7ac915bd762ca1b1c929f089c1b1cf60a633ae3a8e  ./FEW_SHOTS/entity_swap.md
 453a2b09cbf63ec7bbf803f50404b5bcbe271eba3c7d6d9de336c4ac550ca7ed  ./FEW_SHOTS/numeric_rounding_trap.md
-73a4777aeda892c2ebd49a864ed443f9ce339ed1ed54d0f9d962abfe5c4499d6  ./GOLDEN_12_TESTSET.json
+a309bf651ad7cdb5693b12207257101b7c71e3e9effefa4dc5091ae50b529c50  ./GOLDEN_12_TESTSET.json
 b7f1e1dccdd7d09c62bb13493dfdd1f7fe20d8927aa784a63d79d52eca2fa45b  ./README.md
 cbb93fd8e0bfe85179c93e380d94f06d60398f7f06fb06e015110f8811738c06  ./SCHEMAS/output_contract.schema.json
 a8da334f99b7dcb1861a483da6deb59c6c2e312c48b092200a856cc48a7c35dc  ./SYSTEM_PROMPT.md
@@ -18,4 +18,4 @@ c9058cb4519c380112f0669060d5895d51b4462d28f331ae120d20812a2cd45f  ./scripts/chec
 39b8efd8e94b103a068d6051c923cf952cb77664d7376fbc6c6a553905c22b18  ./scripts/quickstart.sh
 6eca88bdc8cfb2c3a38ae8f5ca0e2fea08c1b47bcc38cee0508eac982ff4d149  ./scripts/validate.sh
 69e3c89382ff311da8da369711c46927434854438fec690e53b06f29d7aef61f  ./tests/__pycache__/test_bundle.cpython-312-pytest-8.4.1.pyc
-44044c91e1dd0a38ec8a304b794bca9256f98bd865d7192f3f6f09b42df1b47d  ./tests/test_bundle.py
+201e74b3bdc2cb5cabed3b9d897c1a7a41a124ebd81c591fa502f3b49eb3451e  ./tests/test_bundle.py

--- a/prompts/factsynth_judge/tests/test_bundle.py
+++ b/prompts/factsynth_judge/tests/test_bundle.py
@@ -6,4 +6,6 @@ def test_golden_12():
     data = json.loads((root / "GOLDEN_12_TESTSET.json").read_text())
     assert isinstance(data, list) and len(data) == 12
     for item in data:
-        assert isinstance(item, str) and item
+        assert isinstance(item, dict)
+        for field in ("id", "context", "question", "expected"):
+            assert field in item


### PR DESCRIPTION
## Summary
- structure Factsynth Judge golden test set into objects with `id`, `context`, `question`, and `expected`
- assert new object fields in test bundle
- refresh checksums for updated files

## Testing
- `pytest prompts/factsynth_judge/tests/test_bundle.py`


------
https://chatgpt.com/codex/tasks/task_e_68c08cfc2a788329bd80a3be9ad504dc