### PR TITLE
Restrict FactSynth judge output schema

### DIFF
--- a/prompts/factsynth_judge/SCHEMAS/output_contract.schema.json
+++ b/prompts/factsynth_judge/SCHEMAS/output_contract.schema.json
@@ -59,7 +59,7 @@
     },
     "VERDICT": {"type": "string", "enum": ["supported", "partially_supported", "refuted", "not_provable"]},
     "NORMALIZATION": {"type": "string"},
-    "CONFLICTS": {"oneOf": [{"type": "string"}, {"type": "array"}]},
+    "CONFLICTS": {"type": "array", "items": {"type": "string"}},
     "HYPOTHESIS": {"type": "string"},
     "EVIDENCE_GAP": {"type": "array", "items": {"type": "string"}},
     "METRICS": {
@@ -81,5 +81,6 @@
         "calibration_hint": {"type": "string"}
       }
     }
-  }
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- disable unexpected fields in judge output schema via `additionalProperties: false`
- simplify `CONFLICTS` validation by forcing array of strings

## Testing
- `pre-commit run --files prompts/factsynth_judge/SCHEMAS/output_contract.schema.json`
- `pytest prompts/factsynth_judge/tests`

------
https://chatgpt.com/codex/tasks/task_e_68c08cfd266883299b53dbfccc73891f