### PR TITLE
Suppress DC bias before FFT and skip zero-frequency bin

### DIFF
--- a/src/factsynth_ultimate/isr/sim.py
+++ b/src/factsynth_ultimate/isr/sim.py
@@ -61,11 +61,13 @@ def gamma_spectrum(y: jnp.ndarray, idx: int = 5, fs: Optional[float]=None, ts: O
         if ts is None:
             raise ValueError("Provide fs or ts to infer sampling rate")
         fs = estimate_fs(ts)
-    spec = jnp.abs(jnp.fft.fft(sig))
+    sig = sig - jnp.mean(sig)
+    sig = jnp.diff(sig)
+    spec = jnp.abs(jnp.fft.rfft(sig))
     return spec
 
 def dominant_freq(spec: jnp.ndarray, fs: float) -> float:
-    n = spec.shape[0]
-    freqs = jnp.fft.fftfreq(n, d=1.0/fs)
-    idx = int(jnp.argmax(spec))
-    return float(jnp.abs(freqs[idx]))
+    n = (spec.shape[0] - 1) * 2
+    freqs = jnp.fft.rfftfreq(n, d=1.0/fs)
+    idx = int(jnp.argmax(spec[1:] * freqs[1:]) + 1)
+    return float(freqs[idx])


### PR DESCRIPTION
## Summary
- Remove DC component and take discrete derivative before FFT to compute gamma spectrum
- Ignore the 0 Hz bin and weight frequencies when finding dominant oscillation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09dd38d7883299f4405dcb071451b