### PR TITLE
Use digest reference for SBOM workflow image

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -72,7 +72,9 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/${{ github.repository_owner }}/factsynth:latest
+          # yamllint disable rule:line-length
+          image: ghcr.io/${{ github.repository_owner }}/factsynth@${{ needs.build.outputs.digest }}
+          # yamllint enable rule:line-length
           format: spdx-json
           output-file: sbom.spdx.json
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Ensure SBOM generation uses the exact image digest from the build job

## Testing
- `yamllint .github/workflows/container-release.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c12813e7188329975e6c780c122bab