### PR TITLE
Handle optional dependency tests gracefully

### DIFF
--- a/tests/test_akpshi.py
+++ b/tests/test_akpshi.py
@@ -1,8 +1,8 @@
 import pytest
 
-from factsynth_ultimate.akpshi.metrics import fcr, pfi, rmse
-
 pytest.importorskip("numpy")
+
+from factsynth_ultimate.akpshi.metrics import fcr, pfi, rmse
 
 EXPECTED_FCR = 0.9
 

--- a/tests/test_isr.py
+++ b/tests/test_isr.py
@@ -1,6 +1,9 @@
 
 import pytest
 
+jax = pytest.importorskip("jax")
+pytest.importorskip("diffrax")
+
 from factsynth_ultimate.isr import (
     ISRParams,
     dominant_freq,
@@ -9,8 +12,6 @@ from factsynth_ultimate.isr import (
     simulate_isr,
 )
 
-jax = pytest.importorskip("jax")
-pytest.importorskip("diffrax")
 jnp = jax.numpy
 
 MIN_DOM_FREQ = 25.0

--- a/tests/test_ndmaco.py
+++ b/tests/test_ndmaco.py
@@ -1,9 +1,9 @@
 
 import pytest
 
-from factsynth_ultimate.ndmaco.kuramoto import NDMACO
-
 pytest.importorskip("numpy")
+
+from factsynth_ultimate.ndmaco.kuramoto import NDMACO
 
 MIN_TIME_POINTS = 10
 EXPECTED_CHANNELS = 5

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -2,6 +2,8 @@ import os
 import pathlib
 
 import pytest
+
+schemathesis = pytest.importorskip("schemathesis")
 from schemathesis import openapi
 
 BASE_URL = os.getenv("FACTSYNTH_BASE_URL", "http://127.0.0.1:8000")


### PR DESCRIPTION
## Summary
- Skip akpshi, ndmaco, ISR, and OpenAPI contract tests when optional libraries are missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c13d43539c83298d4065c1474d9d9d