### PR TITLE
fix: use built image digest in release workflow

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -38,6 +40,7 @@ jobs:
             type=ref,event=tag
             type=sha
       - name: Build & push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -55,7 +58,9 @@ jobs:
       - name: Scan image
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/factsynth@${{ needs.build.outputs.digest }}  # yamllint disable-line rule:line-length
+          # yamllint disable rule:line-length
+          image-ref: ghcr.io/${{ github.repository_owner }}/factsynth@${{ needs.build.outputs.digest }}
+          # yamllint enable rule:line-length
           ignore-unfixed: true
           exit-code: '1'
       - name: Upload SARIF
@@ -84,14 +89,17 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Pull image
-        run: docker pull ghcr.io/${{ github.repository_owner }}/factsynth:latest
+      - name: Pull exact image
+        run: docker pull ghcr.io/${{ github.repository_owner }}/factsynth@${{ needs.build.outputs.digest }}
       - name: Run & probe
+        shell: bash
         run: |
           docker run -d --rm -p 8000:8000 \
             --name factsynth \
-            ghcr.io/${{ github.repository_owner }}/factsynth:latest
-          for i in $(seq 1 30); do
+            ghcr.io/${{ github.repository_owner }}/factsynth@${{ needs.build.outputs.digest }}
+          for i in $(seq 1 45); do
             curl -fsS http://127.0.0.1:8000/v1/healthz && exit 0 || sleep 2
           done
-          docker logs factsynth; exit 1
+          echo "Health check failed; recent logs:" >&2
+          docker logs --tail=200 factsynth >&2
+          exit 1


### PR DESCRIPTION
## Summary
- expose build step digest and use it for scanning and smoke tests
- pull and probe the exact built image to avoid tag drift

## Testing
- `pytest -q`
- `pre-commit run --files .github/workflows/container-release.yml` *(fails: Interrupted (KeyboardInterrupt))*

------
https://chatgpt.com/codex/tasks/task_e_68c147a6d7388329b93a20d1e8e2cafb