### PR TITLE
Enforce API key presence in production

### DIFF
--- a/src/factsynth_ultimate/app.py
+++ b/src/factsynth_ultimate/app.py
@@ -73,9 +73,12 @@ def create_app(
             IPAllowlistMiddleware, cidrs=settings.ip_allowlist
         )
     app.add_middleware(BodySizeLimitMiddleware)
+    api_key = read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY")
+    if settings.env == "prod" and api_key in {"", "change-me"}:
+        raise RuntimeError("API key must be set in production")
     app.add_middleware(
         APIKeyAuthMiddleware,
-        api_key=read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY"),
+        api_key=api_key,
         header_name=settings.auth_header_name,
         skip=tuple(settings.skip_auth_paths),
     )

--- a/tests/test_api_key_prod.py
+++ b/tests/test_api_key_prod.py
@@ -1,0 +1,15 @@
+import pytest
+
+from factsynth_ultimate.app import create_app
+
+
+@pytest.mark.parametrize("api_key", [None, "", "change-me"])
+def test_prod_env_requires_real_api_key(monkeypatch, api_key):
+    monkeypatch.setenv("ENV", "prod")
+    monkeypatch.delenv("API_KEY_FILE", raising=False)
+    if api_key is None:
+        monkeypatch.delenv("API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("API_KEY", api_key)
+    with pytest.raises(RuntimeError):
+        create_app()


### PR DESCRIPTION
## Summary
- reject default or empty API keys when ENV=prod
- add regression test covering production API key requirement

## Testing
- `pre-commit run --files src/factsynth_ultimate/app.py tests/test_api_key_prod.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1502b51f08329aae94276fbdfd4a8