### PR TITLE
chore: pin runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.0.4] - 2025-09-10
+- Pin runtime dependencies with explicit version ranges.
+
 ## [1.0.3-incubation-pack] - 2025-09-08
 - Додано Incubation Co‑Dev пакет: GitHub Action, Helm chart, канонічний релізний ZIP, OpenAPI контракт‑тест.
 - Підготовлено Makefile‑таргети release/sbom/checksums/test-contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "factsynth-ultimate-pro"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
-    "fastapi",
-    "uvicorn",
-    "httpx",
-    "pydantic>=2.0",
-    "pydantic-settings>=2.0",
-    "prometheus-client",
-    "regex",
+    "fastapi>=0.116,<0.117",
+    "uvicorn>=0.35,<0.36",
+    "httpx>=0.28,<0.29",
+    "pydantic>=2.11,<2.12",
+    "pydantic-settings>=2.10,<2.11",
+    "prometheus-client>=0.22,<0.23",
+    "regex>=2025.9,<2026",
 ]
 
 [project.optional-dependencies]
@@ -25,7 +25,7 @@ dev = [
     "pytest-cov",  # coverage plugin
 ]
 ops = [
-    "prometheus-client",
+    "prometheus-client>=0.22,<0.23",
 ]
 isr = [
     "jax",


### PR DESCRIPTION
## Summary
- specify explicit version ranges for core runtime dependencies
- record dependency pinning in changelog

## Testing
- `pytest`
- `scripts/release/make_release.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1502cb2788329ad0c8df5e5801346