### PR TITLE
Add production Helm values and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ docker run -e API_KEY=change-me -p 8000:8000 factsynth:1.0.3
 ```bash
 helm registry login ghcr.io -u <user> --password <token>
 helm upgrade --install factsynth oci://ghcr.io/<owner>/charts/factsynth \
+  -f values-prod.yaml \
   --set secrets.apiKey=change-me \
   --set ingress.enabled=true \
   --set ingress.host=factsynth.local

--- a/charts/factsynth/values-prod.yaml
+++ b/charts/factsynth/values-prod.yaml
@@ -1,0 +1,42 @@
+replicaCount: 3
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+pdb:
+  enabled: true
+  minAvailable: 2
+
+hpa:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 60
+
+ingress:
+  enabled: true
+  host: factsynth.local
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/proxy-body-size: 1m
+
+env:
+  ENV: prod
+  RATE_LIMIT_PER_MIN: 240
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+  OTEL_SERVICE_NAME: factsynth


### PR DESCRIPTION
## Summary
- add `values-prod.yaml` with production overrides (replicas, resources, security context, PDB, HPA, ingress annotations, env vars)
- reference `values-prod.yaml` in Helm install instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c156b345908329ada114e70e388b6a