### PR TITLE
feat(chart): add startup probe and security context

### DIFF
--- a/charts/factsynth/templates/deployment.yaml
+++ b/charts/factsynth/templates/deployment.yaml
@@ -12,8 +12,17 @@ spec:
       labels:
         app: factsynth
     spec:
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.securityContext.pod }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: factsynth
+          {{- with .Values.securityContext.container }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           ports:
             - containerPort: 8000
@@ -43,4 +52,9 @@ spec:
             httpGet:
               path: /v1/healthz
               port: 8000
+          startupProbe: {{- toYaml .Values.startupProbe | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep","15"]
           resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/factsynth/values-prod.yaml
+++ b/charts/factsynth/values-prod.yaml
@@ -9,14 +9,25 @@ resources:
     memory: 512Mi
 
 securityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop:
-      - ALL
-  seccompProfile:
-    type: RuntimeDefault
+  pod:
+    runAsNonRoot: true
+    runAsUser: 1000
+  container:
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+startupProbe:
+  httpGet:
+    path: /v1/healthz
+    port: 8000
+  failureThreshold: 30
+  periodSeconds: 10
 
 pdb:
   enabled: true

--- a/charts/factsynth/values.yaml
+++ b/charts/factsynth/values.yaml
@@ -28,6 +28,17 @@ ingress:
 
 resources: {}
 
+securityContext:
+  pod: {}
+  container: {}
+
+startupProbe:
+  httpGet:
+    path: /v1/healthz
+    port: 8000
+  failureThreshold: 30
+  periodSeconds: 10
+
 otelCollector:
   enabled: false
   image:


### PR DESCRIPTION
## Summary
- add termination grace period and optional security contexts to deployment
- expose configurable startup probe and preStop lifecycle

## Testing
- `pre-commit run --files charts/factsynth/templates/deployment.yaml charts/factsynth/values.yaml charts/factsynth/values-prod.yaml`
- `helm lint charts/factsynth` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15815f4dc8329abbc2869a7b6444c