### PR TITLE
feat(helm): expose ingress annotations

### DIFF
--- a/charts/factsynth/README.md
+++ b/charts/factsynth/README.md
@@ -1,0 +1,27 @@
+# FactSynth Helm Chart
+
+## Ingress Options
+
+The chart exposes `.Values.ingress.annotations` for custom [NGINX Ingress](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) settings.
+
+### HTTPS Redirect
+
+Enable automatic redirects from HTTP to HTTPS by adding this annotation:
+
+```yaml
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+```
+
+### Request Body Size
+
+Limit the maximum upload size processed by NGINX:
+
+```yaml
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 1m
+```
+
+Adjust the `1m` value as required.

--- a/charts/factsynth/templates/ingress.yaml
+++ b/charts/factsynth/templates/ingress.yaml
@@ -3,7 +3,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: factsynth
-  annotations: {}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:

--- a/charts/factsynth/values-prod.yaml
+++ b/charts/factsynth/values-prod.yaml
@@ -44,7 +44,16 @@ ingress:
   host: factsynth.local
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "63072000"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
+    nginx.ingress.kubernetes.io/hsts-preload: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: 1m
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Content-Security-Policy: default-src 'self'";
+      more_set_headers "X-Frame-Options: DENY";
+      more_set_headers "Referrer-Policy: no-referrer";
 
 env:
   ENV: prod


### PR DESCRIPTION
## Summary
- allow templated ingress annotations
- set security headers and proxy limits in prod values
- document HTTPS redirect and body size control

## Testing
- `pytest`
- `helm lint charts/factsynth` *(fails: command not found: helm)*

------
https://chatgpt.com/codex/tasks/task_e_68c15a3ba5fc8329b5728b3949af249e