### PR TITLE
Add security, container scan, release, and e2e load workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,30 @@ jobs:
         with:
           name: coverage-xml-${{ matrix.py }}
           path: coverage.xml
+
+  security:
+    name: Security (pip-audit/schemathesis/syft)
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12", cache: "pip" }
+      - name: Install tools
+        run: |
+          python -m pip install -U pip
+          pip install pip-audit schemathesis
+      - name: pip-audit
+        run: pip-audit
+      - name: Schemathesis
+        run: schemathesis run openapi/openapi.yaml
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          output-file: sbom.spdx.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,0 +1,39 @@
+name: container-scan
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:pr-${{ github.sha }}
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:pr-${{ github.sha }}
+          format: table
+      - uses: sigstore/cosign-installer@v3
+      - name: Cosign sign
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: cosign sign ghcr.io/${{ github.repository }}:pr-${{ github.sha }}

--- a/.github/workflows/e2e-load.yml
+++ b/.github/workflows/e2e-load.yml
@@ -1,0 +1,63 @@
+name: e2e-load
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  load:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12", cache: "pip" }
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          pip install -e .[dev] locust
+      - name: Start server
+        env: { API_KEY: change-me }
+        run: |
+          uvicorn factsynth_ultimate.app:app --port 8000 &
+          sleep 5
+      - name: Write k6 script
+        run: |
+          cat <<'KS' > k6-smoke.js
+          import http from 'k6/http';
+          import ws from 'k6/ws';
+          import { check } from 'k6';
+          export default function () {
+            const headers = { 'x-api-key': 'change-me', 'Content-Type': 'application/json' };
+            check(http.post('http://localhost:8000/v1/generate', JSON.stringify({text:'hi'}), { headers }), { 'generate': r => r.status < 500 });
+            check(http.post('http://localhost:8000/v1/intent_reflector', JSON.stringify({intent:'hi'}), { headers }), { 'intent': r => r.status == 200 });
+            check(http.post('http://localhost:8000/v1/stream', JSON.stringify({text:'hi'}), { headers }), { 'sse': r => r.status == 200 });
+            ws.connect('ws://localhost:8000/ws/stream', { headers }, socket => {
+              socket.on('open', () => { socket.send('hi'); socket.close(); });
+            });
+          }
+          KS
+      - name: k6 smoke
+        uses: grafana/k6-action@v0.3.0
+        with:
+          filename: k6-smoke.js
+      - name: Locust smoke
+        run: |
+          cat <<'PY' > locustfile.py
+          from locust import HttpUser, task
+          class User(HttpUser):
+              headers = {"x-api-key": "change-me"}
+              @task
+              def generate(self):
+                  self.client.post("/v1/generate", json={"text": "hi"}, headers=self.headers)
+              @task
+              def intent(self):
+                  self.client.post("/v1/intent_reflector", json={"intent": "hi"}, headers=self.headers)
+              @task
+              def stream(self):
+                  self.client.post("/v1/stream", json={"text": "hi"}, headers=self.headers)
+          PY
+          locust -f locustfile.py --headless -u 1 -r 1 -t 10s --host=http://localhost:8000

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,40 @@
+name: release-chart
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read version
+        run: echo "VERSION=$(grep '^version = "' pyproject.toml | cut -d '"' -f2)" >> $GITHUB_ENV
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/factsynth:${{ env.VERSION }}
+      - uses: azure/setup-helm@v4
+      - name: Package chart
+        run: helm package charts/factsynth --version $VERSION --app-version $VERSION
+      - name: Push chart
+        env:
+          HELM_REGISTRY: ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+          helm push factsynth-$VERSION.tgz oci://$HELM_REGISTRY


### PR DESCRIPTION
## Summary
- extend CI with pip-audit, Schemathesis, and Syft SBOM
- add workflows for container scanning/signing, chart release, and load testing

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/container-scan.yml .github/workflows/release-chart.yml .github/workflows/e2e-load.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c161a445948329a1906d7b234b9219