### PR TITLE
Restrict container scan build on pull requests

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,0 +1,38 @@
+---
+name: Container Scan
+'on':
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        if: github.event_name != 'pull_request'
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          provenance: false
+      - name: Scan image
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ${{ steps.build.outputs.imageid }}
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy.sarif'
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif


### PR DESCRIPTION
## Summary
- add container scan workflow
- skip building/pushing container images on pull request events

## Testing
- `pytest -q`
- `pre-commit run --files .github/workflows/container-scan.yml` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68c165a24e488329978c1a0bd201c720