### PR TITLE
ci: run schemathesis in dry-run mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,17 @@ jobs:
         with:
           name: coverage-xml-${{ matrix.py }}
           path: coverage.xml
+
+  schemathesis:
+    name: Schemathesis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12", cache: "pip" }
+      - name: Install Schemathesis
+        run: |
+          python -m pip install -U pip
+          pip install schemathesis
+      - name: Schemathesis
+        run: schemathesis run --dry-run openapi/openapi.yaml


### PR DESCRIPTION
## Summary
- add Schemathesis job using dry-run mode in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c165a3bdb48329b78762b3c4029748