### PR TITLE
Run Schemathesis dry-run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
           python -m pip install -U pip
           pip install -e .[dev,ops] || pip install -e .
           pip install -U pytest pytest-cov
+      - name: Validate OpenAPI with Schemathesis
+        run: schemathesis run --dry-run openapi/openapi.yaml
       - name: Run smoke tests
         env: { PYTHONPATH: src }
         run: |


### PR DESCRIPTION
## Summary
- validate OpenAPI spec with Schemathesis dry-run so CI doesn't require a running API server

## Testing
- `python -m pre_commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c167e1ffe483299b9843e7a3399000