### PR TITLE
Enforce WebSocket API key authentication

### DIFF
--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -21,6 +21,8 @@ from ..services.runtime import reflect_intent, score_payload, tokenize_preview
 
 logger=logging.getLogger(__name__)
 
+API_KEY = read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY")
+
 api=APIRouter()
 
 @api.get("/v1/version")
@@ -77,8 +79,7 @@ async def ws_stream(ws: WebSocket):
     await ws.accept()
     # simple auth: expect x-api-key matching the configured API key
     key = ws.headers.get("x-api-key")
-    actual_key = read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY")
-    if key != actual_key:
+    if key != API_KEY:
         await ws.close(code=4401, reason="Unauthorized")
         return
     try:

--- a/tests/test_ws_stream.py
+++ b/tests/test_ws_stream.py
@@ -23,3 +23,14 @@ def test_ws_stream_bad_key():
     ):
         ws.receive_json()
     assert exc_info.value.code == UNAUTHORIZED
+
+
+def test_ws_stream_bad_key_on_send():
+    c = TestClient(app)
+    with (
+        c.websocket_connect("/ws/stream", headers={"x-api-key": "wrong"}) as ws,
+        pytest.raises(WebSocketDisconnect) as exc_info,
+    ):
+        ws.send_text("ignored")
+        ws.receive_json()
+    assert exc_info.value.code == UNAUTHORIZED


### PR DESCRIPTION
## Summary
- load API key once in routers and reuse for WebSocket auth
- reject WebSocket clients with wrong key via code 4401
- add tests for unauthorized WebSocket connections

## Testing
- `pre-commit run --files src/factsynth_ultimate/api/routers.py tests/test_ws_stream.py`
- `pytest tests/test_ws_stream.py::test_ws_stream_bad_key tests/test_ws_stream.py::test_ws_stream_bad_key_on_send -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16c73eb3483298f697fb6e16b4b7a