### PR TITLE
test: add CSV parsing tests for settings

### DIFF
--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -1,7 +1,33 @@
 import pytest
 from pydantic import ValidationError
 
-from factsynth_ultimate.core.settings import load_settings
+from factsynth_ultimate.core.settings import Settings, load_settings
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "cors_allow_origins",
+        "skip_auth_paths",
+        "ip_allowlist",
+        "health_tcp_checks",
+    ],
+)
+def test_csv_fields(field):
+    settings = Settings(**{field: "a,b"})
+    assert getattr(settings, field) == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", []),
+        ("one", ["one"]),
+        ("a, b", ["a", " b"]),
+    ],
+)
+def test_split_csv_edge_cases(raw, expected):
+    assert Settings._split_csv(raw) == expected
 
 
 def test_invalid_rate_limit_per_minute(monkeypatch):


### PR DESCRIPTION
## Summary
- test CSV string parsing for settings lists
- cover _split_csv edge cases

## Testing
- `pre-commit run --files tests/test_settings_validation.py`
- `pytest tests/test_settings_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68c16fa489348329b3183398a5e51173