### PR TITLE
Add websocket token order test

### DIFF
--- a/tests/test_ws_stream.py
+++ b/tests/test_ws_stream.py
@@ -7,12 +7,21 @@ from factsynth_ultimate.app import app
 UNAUTHORIZED = 4401
 
 
-def test_ws_stream_smoke():
+def test_ws_stream_tokens_complete():
     c = TestClient(app)
-    with c.websocket_connect("/ws/stream", headers={"x-api-key":"change-me"}) as ws:
-        ws.send_text("hello world")
-        msg = ws.receive_json()
-        assert "t" in msg or "end" in msg
+    with c.websocket_connect("/ws/stream", headers={"x-api-key": "change-me"}) as ws:
+        ws.send_text("one two")
+        msgs = []
+        while True:
+            msg = ws.receive_json()
+            msgs.append(msg)
+            if msg.get("end"):
+                break
+
+    assert msgs[0]["t"] == "one"
+    assert msgs[1]["t"] == "two"
+    assert msgs[2] == {"end": True}
+    assert len(msgs) == 3
 
 
 def test_ws_stream_bad_key():


### PR DESCRIPTION
## Summary
- expand ws stream smoke test to validate token order and completion
- keep bad API key websocket authorization tests

## Testing
- `pytest tests/test_ws_stream.py`


------
https://chatgpt.com/codex/tasks/task_e_68c16fa56a588329b3beb58aa38cc083