### PR TITLE
docs: update security contact information

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,1 @@
-Report vulnerabilities to security@example.com. Avoid public issues for sensitive findings.
+Report vulnerabilities to https://github.com/neuron7x/FactSynth/security/advisories/new. Avoid public issues for sensitive findings.


### PR DESCRIPTION
## Summary
- replace placeholder security email with link to GitHub Security Advisories form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1725c427c83298a6c757192bb2268