### PR TITLE
Skip WebSocket stream tests when FastAPI or Starlette missing

### DIFF
--- a/tests/test_ws_stream.py
+++ b/tests/test_ws_stream.py
@@ -1,4 +1,8 @@
 import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("starlette")
+
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 


### PR DESCRIPTION
## Summary
- Guard WebSocket streaming tests with `pytest.importorskip` for `fastapi` and `starlette`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17c0550fc83298f89fac46cce5907