### PR TITLE
refactor: use constant for expected items

### DIFF
--- a/prompts/factsynth_judge/tests/test_bundle.py
+++ b/prompts/factsynth_judge/tests/test_bundle.py
@@ -1,10 +1,12 @@
 import json
 from pathlib import Path
 
+EXPECTED_ITEMS = 12
+
 def test_golden_12():
     root = Path(__file__).resolve().parents[1]
     data = json.loads((root / "GOLDEN_12_TESTSET.json").read_text())
-    assert isinstance(data, list) and len(data) == 12
+    assert isinstance(data, list) and len(data) == EXPECTED_ITEMS
     for item in data:
         assert isinstance(item, dict)
         for field in ("id", "context", "question", "expected"):

--- a/prompts/github_codex_ops/tests/test_bundle.py
+++ b/prompts/github_codex_ops/tests/test_bundle.py
@@ -1,9 +1,11 @@
 import json
 from pathlib import Path
 
+EXPECTED_ITEMS = 12
+
 def test_golden_12():
     root = Path(__file__).resolve().parents[1]
     data = json.loads((root / "GOLDEN_12_TESTSET.json").read_text())
-    assert isinstance(data, list) and len(data) == 12
+    assert isinstance(data, list) and len(data) == EXPECTED_ITEMS
     for item in data:
         assert "id" in item and "description" in item


### PR DESCRIPTION
## Summary
- replace magic number with named constant in judge and ops bundle tests
- reorder imports via `ruff`

## Testing
- `ruff check --fix prompts/factsynth_judge/tests/test_bundle.py prompts/github_codex_ops/tests/test_bundle.py`
- `pytest prompts/factsynth_judge/tests/test_bundle.py -q`
- `pytest prompts/github_codex_ops/tests/test_bundle.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17f9664b8832988076f6513b34504