### PR TITLE
feat: allow simulate_isr defaults

### DIFF
--- a/src/factsynth_ultimate/isr/sim.py
+++ b/src/factsynth_ultimate/isr/sim.py
@@ -43,8 +43,12 @@ def _ds_dt(t, S, args):
     Gamma = _compute_gamma(t)
     return alpha * IRS - beta * ES + gamma_param * AS_star + delta * Gamma
 
-def simulate_isr(S0: jnp.ndarray = jnp.array([1.0, 0.8, 0.5, 0.3, 0.2, 0.1, 0.05]),
-                 params: ISRParams = ISRParams()) -> Dict[str, jnp.ndarray]:
+def simulate_isr(S0: jnp.ndarray | None = None,
+                 params: ISRParams | None = None) -> Dict[str, jnp.ndarray]:
+    if S0 is None:
+        S0 = jnp.array([1.0, 0.8, 0.5, 0.3, 0.2, 0.1, 0.05])
+    if params is None:
+        params = ISRParams()
     term = ODETerm(lambda t, y, _: _ds_dt(t, y, (params.alpha, params.beta, params.gamma_param, params.delta)))
     solver = Tsit5()
     ts = jnp.linspace(params.t0, params.t1, params.steps)


### PR DESCRIPTION
## Summary
- let `simulate_isr` accept optional initial state and parameters and set defaults when `None`

## Testing
- `pre-commit run --files src/factsynth_ultimate/isr/sim.py`
- `pytest tests/test_isr.py -q` *(fails: assert 25.0 <= 0.0)*


------
https://chatgpt.com/codex/tasks/task_e_68c17f972f188329b866d9bb8b2a0094