### PR TITLE
Clarify prompt test packages for mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,4 @@ warn_unused_ignores = False
 warn_redundant_casts = False
 warn_return_any = False
 disallow_untyped_defs = False
+exclude = ^prompts/[^/]+/tests/

--- a/prompts/factsynth_judge/__init__.py
+++ b/prompts/factsynth_judge/__init__.py
@@ -1,0 +1,1 @@
+"""Factsynth judge prompts package."""

--- a/prompts/factsynth_judge/tests/__init__.py
+++ b/prompts/factsynth_judge/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Factsynth judge prompts."""

--- a/prompts/github_codex_ops/__init__.py
+++ b/prompts/github_codex_ops/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub Codex Ops prompts package."""

--- a/prompts/github_codex_ops/tests/__init__.py
+++ b/prompts/github_codex_ops/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for GitHub Codex Ops prompts."""


### PR DESCRIPTION
## Summary
- add __init__ files in prompt test directories to avoid duplicate module names
- exclude prompt test directories from mypy

## Testing
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c17f98c7848329a798dd45d3ef47a1