### PR TITLE
Restrict callback success to 2xx responses

### DIFF
--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -111,7 +111,7 @@ async def _post_callback(  # noqa: PLR0913
             attempt_num = i
             try:
                 r = await client.post(url, json=data)
-                if r.status_code < HTTPStatus.INTERNAL_SERVER_ERROR:
+                if HTTPStatus.OK <= r.status_code < HTTPStatus.MULTIPLE_CHOICES:
                     return
                 last_err = f"HTTP {r.status_code}"
             except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- Only treat 2xx callback responses as success
- Preserve logging and retry behavior for other statuses

## Testing
- `pre-commit run --files src/factsynth_ultimate/api/routers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1970c505c8329a9cd8a282b128c7c