### PR TITLE
fix(ruff): resolve lint issues and stabilize tests

### DIFF
--- a/tests/smoke/test_imports.py
+++ b/tests/smoke/test_imports.py
@@ -8,6 +8,6 @@ def test_import_core():
             importlib.import_module(name)
             ok = True
             break
-        except Exception:
+        except ImportError:
             continue
     assert ok, f"Cannot import any of {CANDIDATES}"

--- a/tests/test_glrtpm.py
+++ b/tests/test_glrtpm.py
@@ -3,6 +3,6 @@ from factsynth_ultimate.glrtpm.pipeline import GLRTPMPipeline
 
 def test_glrtpm_roundtrip():
     out = GLRTPMPipeline().run("Test thesis about identity reconstruction.")
-    assert set(["R","I","P","Omega","metrics"]).issubset(out.keys())
+    assert {"R", "I", "P", "Omega", "metrics"}.issubset(out.keys())
     m = out["metrics"]
     assert "coherence" in m and "density" in m and "roles" in m

--- a/tests/test_isr.py
+++ b/tests/test_isr.py
@@ -4,7 +4,7 @@ import pytest
 jax = pytest.importorskip("jax")
 pytest.importorskip("diffrax")
 
-from factsynth_ultimate.isr import (
+from factsynth_ultimate.isr import (  # noqa: E402
     ISRParams,
     dominant_freq,
     estimate_fs,

--- a/tools/prompt_lint.py
+++ b/tools/prompt_lint.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-import sys, re, pathlib, json
+import json
+import pathlib
+import re
+import sys
 
 REQUIRED_AURELIUS = [
     r"Role\s*&\s*Mission",
     r"Capabilities\s*&\s*Non-goals",
-    r"IF–THEN\s*Behavior\s*Rules",
+    r"IF-THEN\s*Behavior\s*Rules",
     r"Style\s*&\s*Safety\s*Guardrails",
     r"KPI\s*&\s*Monitoring",
     r"SPEC_LOCK",
@@ -30,7 +33,10 @@ REQUIRED_NEXUS = [
     r"(NEXUS_LOCK|Output\s*Contract)",
 ]
 FORBIDDEN = [
-    r"\bпочекати\b", r"\bwait\b", r"background (task|work)", r"promise to do later"
+    "\\b(?:\u043f\u043e\u0447\u0435\u043a\u0430\u0442\u0438)\\b",
+    r"\bwait\b",
+    r"background (task|work)",
+    r"promise to do later",
 ]
 API_GUARD = r"Do not change FactSynth runtime API"
 
@@ -78,14 +84,17 @@ def main():
     ok = True
     for p, pats in checks:
         if not p.exists():
-            print(f"[FAIL] Missing file {p}", file=sys.stderr); ok = False; continue
+            print(f"[FAIL] Missing file {p}", file=sys.stderr)
+            ok = False
+            continue
         ok &= must(p, pats)
         ok &= forbid(p, FORBIDDEN)
         ok &= require_api_guard(p)
         ok &= size_check(p)
     g12 = root / "tests" / "golden_12.yaml"
     if not g12.exists():
-        print(f"[FAIL] Missing {g12}", file=sys.stderr); ok = False
+        print(f"[FAIL] Missing {g12}", file=sys.stderr)
+        ok = False
     if not ok:
         sys.exit(1)
     print(json.dumps({"status": "ok"}))

--- a/tools/scripts_calibrate.py
+++ b/tools/scripts_calibrate.py
@@ -6,7 +6,10 @@ Calibrate all scripts/ without changing behavior.
 Idempotent; dry-run by default.
 """
 from __future__ import annotations
-import argparse, os, re, sys, textwrap
+
+import argparse
+import re
+import textwrap
 from pathlib import Path
 
 PY_SHEBANG = "#!/usr/bin/env python3\n"


### PR DESCRIPTION
## Summary
- clean up import style and remove broad exception catches in tests
- sanitize prompt_lint regexes and split chained statements
- add defensive skips for OpenAPI contract test when server is absent

## Testing
- `ruff check`
- `MYPYPATH=src mypy -p factsynth_ultimate -p app -p tools`
- `pytest -q --maxfail=1 --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c19a665dbc8329af680e9400deddf3