### PR TITLE
Use regex to locate main guard

### DIFF
--- a/tools/scripts_calibrate.py
+++ b/tools/scripts_calibrate.py
@@ -106,9 +106,10 @@ def maybe_argparse_shim(src: str) -> str:
     _ = _parse_args(None)  # no-op, keeps defaults identical
     """
     ).strip("\n")
-    insert_at = src.rfind('if __name__ == "__main__":')
-    if insert_at == -1:
+    m = re.search(r'if\s+__name__\s*==\s*[\'"]__main__[\'"]\s*:', src)
+    if not m:
         return src.rstrip() + "\n\n" + shim + "\n"
+    insert_at = m.start()
     return src[:insert_at] + shim + "\n\n" + src[insert_at:]
 
 


### PR DESCRIPTION
## Summary
- inject argparse shim before `if __name__ == "__main__":` via regex search, handling varying whitespace and quote styles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c19dc7ac388329bfab8fae69b8ba0b