### PR TITLE
Handle connectivity issues in OpenAPI contract test

### DIFF
--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -2,9 +2,10 @@ import os
 import pathlib
 
 import pytest
+import requests
 
 schemathesis = pytest.importorskip("schemathesis")
-from schemathesis import openapi
+from schemathesis import openapi  # noqa: E402
 
 BASE_URL = os.getenv("FACTSYNTH_BASE_URL", "http://127.0.0.1:8000")
 OPENAPI_PATH = os.getenv("FACTSYNTH_OPENAPI", "openapi/openapi.yaml")
@@ -27,5 +28,8 @@ def test_api_conforms(case):
     if case.path not in ["/v1/healthz", "/metrics", "/v1/version"]:
         case.headers = {**(case.headers or {}), "x-api-key": API_KEY}
     case.base_url = BASE_URL
-    response = case.call()
+    try:
+        response = case.call()
+    except requests.exceptions.RequestException:
+        pytest.skip("Could not connect to API; skipping contract tests due to connectivity issues")
     case.validate_response(response)


### PR DESCRIPTION
## Summary
- Catch `requests.exceptions.RequestException` during contract test calls and skip on connectivity failure
- Add `requests` import and clarify skip message

## Testing
- `ruff check tests/test_openapi_contract.py`
- `pytest -q tests/test_openapi_contract.py` *(skipped: could not import 'schemathesis')*


------
https://chatgpt.com/codex/tasks/task_e_68c19dc70b748329888a14092f13dea6