### PR TITLE
Remove leading blank line in test_isr.py

### DIFF
--- a/tests/test_isr.py
+++ b/tests/test_isr.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 jax = pytest.importorskip("jax")


### PR DESCRIPTION
## Summary
- ensure tests/test_isr.py begins with its import by removing the initial blank line

## Testing
- `pytest tests/test_isr.py -q` *(skipped: could not import 'jax')*

------
https://chatgpt.com/codex/tasks/task_e_68c19dc5fce8832997a47ebf32e3dfd5