### PR TITLE
Add quality policy loader and scoring utilities

### DIFF
--- a/config/quality_policy.yaml
+++ b/config/quality_policy.yaml
@@ -1,0 +1,8 @@
+weights:
+  SQS: 0.7
+  ESS: 0.3
+filters:
+  min_score: 0.5
+  banned_topics:
+    - violence
+    - explicit

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,15 @@
+from .quality import (
+    compute_ess,
+    compute_sqs,
+    lexical_diversity,
+    load_quality_policy,
+    pairwise_jaccard,
+)
+
+__all__ = [
+    "compute_ess",
+    "compute_sqs",
+    "lexical_diversity",
+    "load_quality_policy",
+    "pairwise_jaccard",
+]

--- a/src/app/quality/__init__.py
+++ b/src/app/quality/__init__.py
@@ -1,0 +1,11 @@
+from .diversity import lexical_diversity, pairwise_jaccard
+from .policy import load_quality_policy
+from .score import compute_ess, compute_sqs
+
+__all__ = [
+    "compute_ess",
+    "compute_sqs",
+    "lexical_diversity",
+    "load_quality_policy",
+    "pairwise_jaccard",
+]

--- a/src/app/quality/diversity.py
+++ b/src/app/quality/diversity.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Sequence
+
+MIN_TEXTS = 2
+
+
+def lexical_diversity(text: str) -> float:
+    """Calculate lexical diversity of a text as unique tokens over total tokens."""
+    tokens = text.split()
+    if not tokens:
+        return 0.0
+    return len(set(tokens)) / len(tokens)
+
+
+def pairwise_jaccard(texts: Sequence[str]) -> float:
+    """Average pairwise Jaccard similarity across texts."""
+    if len(texts) < MIN_TEXTS:
+        return 1.0
+    pairs = list(combinations(texts, MIN_TEXTS))
+    scores = []
+    for a, b in pairs:
+        set_a, set_b = set(a.split()), set(b.split())
+        union = set_a | set_b
+        if not union:
+            scores.append(0.0)
+        else:
+            scores.append(len(set_a & set_b) / len(union))
+    return sum(scores) / len(scores)
+
+
+__all__ = ["lexical_diversity", "pairwise_jaccard"]

--- a/src/app/quality/policy.py
+++ b/src/app/quality/policy.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Tuple
+
+import yaml
+
+
+def load_quality_policy(path: str | Path) -> Tuple[dict[str, Any], str]:
+    """Load a quality policy YAML file and return its data and SHA-256 hash.
+
+    Parameters
+    ----------
+    path: str | Path
+        Path to the YAML policy file.
+
+    Returns
+    -------
+    Tuple[dict[str, Any], str]
+        A tuple containing the loaded policy as a dictionary and the
+        SHA-256 hex digest of the file contents.
+    """
+    policy_path = Path(path)
+    data = policy_path.read_bytes()
+    policy = yaml.safe_load(data) or {}
+    digest = hashlib.sha256(data).hexdigest()
+    return policy, digest

--- a/src/app/quality/score.py
+++ b/src/app/quality/score.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def compute_sqs(text: str) -> float:
+    """Compute a simple Semantic Quality Score (SQS).
+
+    The score is the ratio of unique words to total words.
+    """
+    tokens = text.split()
+    if not tokens:
+        return 0.0
+    return len(set(tokens)) / len(tokens)
+
+
+def compute_ess(texts: Sequence[str]) -> float:
+    """Compute a rudimentary Ensemble Semantic Score (ESS).
+
+    The score is the average SQS across a collection of texts.
+    """
+    if not texts:
+        return 0.0
+    scores = [compute_sqs(t) for t in texts]
+    return sum(scores) / len(scores)
+
+
+__all__ = ["compute_ess", "compute_sqs"]


### PR DESCRIPTION
## Summary
- add YAML quality policy and loader with SHA-256 digest
- provide SQS/ESS scoring helpers and diversity metrics
- expose quality utilities through package exports

## Testing
- `ruff check src/app/quality src/app/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a274f51883298aca6ac78c7a3975