### PR TITLE
Add local retriever, async NLI, and provenance blocks

### DIFF
--- a/src/app/core/factsynth_lock.py
+++ b/src/app/core/factsynth_lock.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class QualityBlock:
+    """Human-assessed quality information for a document."""
+
+    score: float
+    reviewer: str
+    notes: str = ""
+
+
+@dataclass
+class ProvenanceBlock:
+    """Provenance metadata describing the source of a document."""
+
+    source: str
+    url: str | None = None
+    license: str | None = None
+
+
+@dataclass
+class FactSynthLock:
+    """Container bundling quality and provenance information."""
+
+    quality: List[QualityBlock] = field(default_factory=list)
+    provenance: List[ProvenanceBlock] = field(default_factory=list)

--- a/src/app/services/nli.py
+++ b/src/app/services/nli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Awaitable, Callable, Optional
+
+from factsynth_ultimate.tokenization import tokenize
+
+Classifier = Callable[[str, str], Awaitable[float]]
+
+
+class NLI:
+    """Natural language inference with optional async classifier."""
+
+    def __init__(self, classifier: Optional[Classifier] = None) -> None:
+        self.classifier = classifier
+
+    async def classify(self, premise: str, hypothesis: str) -> float:
+        """Return entailment score for *hypothesis* given *premise*.
+
+        If an async *classifier* was provided, it will be awaited. Any exception
+        raised by the classifier triggers a heuristic fallback based on token
+        overlap.
+        """
+
+        if self.classifier is not None:
+            try:
+                return await self.classifier(premise, hypothesis)
+            except Exception:
+                pass
+        return self._heuristic(premise, hypothesis)
+
+    def _heuristic(self, premise: str, hypothesis: str) -> float:
+        p_tokens = {t.lower() for t in tokenize(premise)}
+        h_tokens = {t.lower() for t in tokenize(hypothesis)}
+        if not h_tokens:
+            return 0.0
+        return len(h_tokens & p_tokens) / len(h_tokens)

--- a/tests/test_local_fixture_retriever.py
+++ b/tests/test_local_fixture_retriever.py
@@ -10,6 +10,6 @@ def test_ukrainian_query_matches_english_fixture():
 
     results = retriever.search("Що таке мікросервіси?", k=1)
     assert results, "No results returned"
-    top_fixture, score = results[0]
-    assert top_fixture.id == "en1"
-    assert score > 0
+    top_doc = results[0]
+    assert top_doc.id == "en1"
+    assert top_doc.score > 0

--- a/tests/test_nli.py
+++ b/tests/test_nli.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from app.services.nli import NLI
+
+
+def test_nli_uses_async_classifier():
+    async def classifier(p: str, h: str) -> float:
+        return 0.42
+
+    nli = NLI(classifier)
+    score = asyncio.run(nli.classify("a", "b"))
+    assert score == 0.42
+
+
+def test_nli_fallback_on_error():
+    async def failing_classifier(p: str, h: str) -> float:
+        raise RuntimeError("boom")
+
+    nli = NLI(failing_classifier)
+    score = asyncio.run(nli.classify("Cats are animals", "Cats are animals"))
+    assert score > 0.9


### PR DESCRIPTION
## Summary
- Define `QualityBlock` and `ProvenanceBlock` dataclasses for tracking data quality and source metadata
- Expand local fixture retriever to return typed `RetrievedDoc` results
- Introduce async NLI service with fallback heuristic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a2767be883298bee2441b5c99188