### PR TITLE
Add evaluator service with verify endpoint

### DIFF
--- a/src/app/api/__init__.py
+++ b/src/app/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package for application tests."""
+
+from .verify import api as verify_api, FactSynthLock
+
+__all__ = ["verify_api", "FactSynthLock"]

--- a/src/app/api/verify.py
+++ b/src/app/api/verify.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from threading import Lock
+
+from fastapi import APIRouter, Depends
+
+from ..services.evaluator import evaluate_claim
+
+FactSynthLock = Lock()
+
+api = APIRouter()
+
+
+@api.post("/verify")
+def verify(result: dict = Depends(evaluate_claim)) -> dict:  # noqa: B008
+    """Verify a claim by delegating to :func:`evaluate_claim`.
+
+    The evaluation is resolved via FastAPI's dependency injection. The exported
+    ``FactSynthLock`` can be used by callers wishing to guard concurrent access
+    to evaluation resources.
+    """
+    return result

--- a/src/app/services/evaluator.py
+++ b/src/app/services/evaluator.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any, Callable, Dict, Iterable, Optional
+
+ResultDict = Dict[str, Any]
+
+
+def evaluate_claim(  # noqa: PLR0913
+    claim: str,
+    *,
+    policy_check: Callable[[str], Any] | None = None,
+    scoring: Callable[[str], Any] | None = None,
+    diversity: Callable[[str], Any] | None = None,
+    nli: Callable[[str], Any] | None = None,
+    retriever: Optional[Any] = None,
+) -> ResultDict:
+    """Evaluate *claim* and compose results from several subsystems.
+
+    Parameters
+    ----------
+    claim:
+        The textual claim to analyse.
+    policy_check, scoring, diversity, nli:
+        Optional callables implementing each stage. They are invoked with the
+        claim and their results are merged into the output dictionary under
+        corresponding keys. Missing callables simply yield ``None``.
+    retriever:
+        Optional object providing ``search`` and, optionally, ``close`` methods.
+        If a ``close`` method is present it will be invoked once the evaluation
+        is complete.
+    """
+
+    out: ResultDict = {}
+    with ExitStack() as stack:
+        if retriever and hasattr(retriever, "close"):
+            stack.callback(retriever.close)
+
+        evidence: Iterable[Any] = []
+        if retriever and hasattr(retriever, "search"):
+            try:
+                evidence = retriever.search(claim)
+            except Exception:  # noqa: BLE001 - defensive best effort
+                evidence = []
+        out["evidence"] = list(evidence)
+
+        if policy_check is not None:
+            out["policy"] = policy_check(claim)
+        if scoring is not None:
+            out["score"] = scoring(claim)
+        if diversity is not None:
+            out["diversity"] = diversity(claim)
+        if nli is not None:
+            out["nli"] = nli(claim)
+
+    return out

--- a/tests/test_evaluator_api.py
+++ b/tests/test_evaluator_api.py
@@ -1,0 +1,48 @@
+import inspect
+import threading
+
+from fastapi.params import Depends as DependsParam
+
+from app.api import verify as verify_mod
+from app.services.evaluator import evaluate_claim
+
+
+def test_evaluate_claim_composes_and_closes():
+    class DummyRetriever:
+        def __init__(self):
+            self.closed = False
+
+        def search(self, q):
+            return [(q, 1.0)]
+
+        def close(self):
+            self.closed = True
+
+    retriever = DummyRetriever()
+
+    result = evaluate_claim(
+        "alpha",
+        policy_check=lambda _: {"allowed": True},
+        scoring=lambda _: 0.5,
+        diversity=lambda _: 0.1,
+        nli=lambda _: {"label": "neutral"},
+        retriever=retriever,
+    )
+
+    assert result["policy"] == {"allowed": True}
+    assert result["score"] == 0.5  # noqa: PLR2004
+    assert result["diversity"] == 0.1  # noqa: PLR2004
+    assert result["nli"] == {"label": "neutral"}
+    assert result["evidence"] == [("alpha", 1.0)]
+    assert retriever.closed
+
+
+def test_verify_depends_on_evaluate_and_exposes_lock():
+    assert isinstance(verify_mod.FactSynthLock, type(threading.Lock()))
+
+    sig = inspect.signature(verify_mod.verify)
+    params = list(sig.parameters.values())
+    assert any(
+        isinstance(p.default, DependsParam) and p.default.dependency is evaluate_claim
+        for p in params
+    )


### PR DESCRIPTION
## Summary
- add `evaluate_claim` service that composes policy, scoring, diversity and NLI results while closing retrievers
- add verify API router exposing `FactSynthLock` and depending on `evaluate_claim`
- test evaluator and FastAPI dependency wiring

## Testing
- `ruff check src/app/services/evaluator.py src/app/api/verify.py tests/test_evaluator_api.py`
- `pytest tests/test_local_fixture_retriever.py tests/test_evaluator_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1a276f8908329b0fa11f15f70bd83