### PR TITLE
feat: add FACTSYNTH_LOCK v1.1 contract and quality policy

### DIFF
--- a/config/quality_policy.yaml
+++ b/config/quality_policy.yaml
@@ -1,0 +1,47 @@
+# Compatibility Guard: Do not change FactSynth runtime API
+name: default-quality-policy
+version: "1.0.0"
+
+hard_filters:
+  disallow_tlds: [".zip", ".mov", ".tk", ".click"]
+  allow_filetypes: ["html","pdf"]
+  min_snippet_len: 60
+  min_year: 2005
+
+weights:
+  domain_reputation: 0.22
+  author_credibility: 0.12
+  citation_authority: 0.10
+  method_rigor: 0.16
+  recency: 0.10
+  cross_source_consistency: 0.12
+  conflict_of_interest_penalty: -0.08
+  adversarial_signals_penalty: -0.10
+
+evidence_strength:
+  mapping:
+    primary_research: 0.95
+    standard_spec: 0.90
+    meta_analysis: 0.90
+    systematic_review: 0.85
+    reputable_news: 0.70
+    blog_expert: 0.55
+    forum_post: 0.30
+
+diversity:
+  min_domains: 3
+  enforce_cross_geo: true
+  enforce_media_mix: true
+
+recency:
+  half_life_years: 3
+  timeless_domains: ["ietf.org","w3.org","iso.org","rfc-editor.org"]
+
+thresholds:
+  min_sqs_for_use: 0.55
+  min_ess_for_use: 0.60
+  staleness_days_warn: 1825
+  manual_review_triggers:
+    - "coverage.used_in_synthesis < 2"
+    - "diversity.domain_entropy < 1.0"
+    - "contradictions.conflict_pairs >= 2 and contradictions.max_pair_confidence >= 0.75"

--- a/docs/FACTSYNTH_LOCK.md
+++ b/docs/FACTSYNTH_LOCK.md
@@ -1,0 +1,45 @@
+# FACTSYNTH_LOCK — Output Contract (v1.1)
+**Compatibility Guard: Do not change FactSynth runtime API**
+
+## 1) Verification Verdict
+- **status**: SUPPORTED | REFUTED | UNCLEAR | OUT_OF_SCOPE | ERROR
+- **confidence**: 0.0–1.0 (калібрований)
+- **summary**: ≤300 символів, одне речення висновку
+
+## 2) Source Synthesis
+- **key_findings**: синтез без CoT, ≤1000 символів
+- **citations[]**:
+  - id: string
+  - source: string
+  - snippet: string (≤500)
+  - relevance: number [0..1]
+  - date: YYYY-MM-DD
+  - url: uri
+
+## 3) Traceability & Justification
+- **retrieval_query**: string (≤500)
+- **justification_steps[]**: 3–7 високорівневих кроків (без CoT)
+- **assumptions[]**: ≤10
+
+## 4) Recommendations & Next Steps
+- **next_query_suggestion**: string
+- **gaps_identified[]**: string[]
+- **manual_review**: boolean
+
+## 5) Quality Report (optional)
+- **coverage**: { total_candidates, passed_hard_filters, used_in_synthesis }
+- **quality_scores**: { sqs_median, sqs_iqr, ess_median }
+- **diversity**: { domain_entropy, geo_spread, media_mix:{primary,secondary} }
+- **recency**: { median_age_days, staleness_flag }
+- **contradictions**: { conflict_pairs, max_pair_confidence }
+- **adversarial_risk**: { level: LOW|MEDIUM|HIGH, signals: string[] }
+
+## 6) Provenance (optional)
+- **policy_snapshot_sha256**: string
+- **citation_hashes[]**: sha256(url|date|snippet)
+- **retrieval_id**: string
+
+## 7) Policy Snapshot (optional)
+- **name**: "default-quality-policy"
+- **version**: "1.0.0"
+- **weights**: див. `config/quality_policy.yaml`

--- a/openapi/components/schemas/FactSynthLock_v1_1.yaml
+++ b/openapi/components/schemas/FactSynthLock_v1_1.yaml
@@ -1,0 +1,113 @@
+openapi: 3.0.3
+info: { title: FactSynthLock, version: "1.1.0" }
+components:
+  schemas:
+    FactSynthLock:
+      type: object
+      required: [verdict, source_synthesis, traceability, recommendations]
+      properties:
+        verdict:
+          type: object
+          required: [status, confidence, summary]
+          properties:
+            status: { type: string, enum: [SUPPORTED, REFUTED, UNCLEAR, OUT_OF_SCOPE, ERROR] }
+            confidence: { type: number, minimum: 0, maximum: 1 }
+            summary: { type: string, maxLength: 300 }
+        source_synthesis:
+          type: object
+          required: [key_findings, citations]
+          properties:
+            key_findings: { type: string, maxLength: 1000 }
+            citations:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                required: [id, source, snippet, relevance, date, url]
+                properties:
+                  id: { type: string }
+                  source: { type: string }
+                  snippet: { type: string, maxLength: 500 }
+                  relevance: { type: number, minimum: 0, maximum: 1 }
+                  date: { type: string, format: date }
+                  url: { type: string, format: uri }
+        traceability:
+          type: object
+          required: [retrieval_query, justification_steps, assumptions]
+          properties:
+            retrieval_query: { type: string, maxLength: 500 }
+            justification_steps:
+              type: array
+              minItems: 3
+              maxItems: 7
+              items: { type: string, maxLength: 200 }
+            assumptions:
+              type: array
+              maxItems: 10
+              items: { type: string, maxLength: 200 }
+        recommendations:
+          type: object
+          required: [next_query_suggestion, manual_review]
+          properties:
+            next_query_suggestion: { type: string, maxLength: 200 }
+            gaps_identified:
+              type: array
+              maxItems: 10
+              items: { type: string, maxLength: 200 }
+            manual_review: { type: boolean }
+        quality_report:
+          type: object
+          properties:
+            coverage:
+              type: object
+              properties:
+                total_candidates: { type: integer, minimum: 0 }
+                passed_hard_filters: { type: integer, minimum: 0 }
+                used_in_synthesis: { type: integer, minimum: 0 }
+            quality_scores:
+              type: object
+              properties:
+                sqs_median: { type: number }
+                sqs_iqr: { type: number }
+                ess_median: { type: number }
+            diversity:
+              type: object
+              properties:
+                domain_entropy: { type: number }
+                geo_spread: { type: integer }
+                media_mix:
+                  type: object
+                  properties:
+                    primary: { type: integer }
+                    secondary: { type: integer }
+            recency:
+              type: object
+              properties:
+                median_age_days: { type: integer }
+                staleness_flag: { type: boolean }
+            contradictions:
+              type: object
+              properties:
+                conflict_pairs: { type: integer }
+                max_pair_confidence: { type: number }
+            adversarial_risk:
+              type: object
+              properties:
+                level: { type: string, enum: [LOW, MEDIUM, HIGH] }
+                signals:
+                  type: array
+                  items: { type: string }
+        provenance:
+          type: object
+          properties:
+            policy_snapshot_sha256: { type: string }
+            citation_hashes:
+              type: array
+              items: { type: string }
+            retrieval_id: { type: string }
+        policy_snapshot:
+          type: object
+          properties:
+            name: { type: string }
+            version: { type: string }
+            weights: { type: object }

--- a/openapi/paths/verify.yaml
+++ b/openapi/paths/verify.yaml
@@ -1,0 +1,44 @@
+post:
+  summary: Verify a factual claim and return a FACTSYNTH_LOCK report (v1.1 compatible)
+  operationId: postVerify
+  tags: [verify]
+  security: [ { ApiKeyAuth: [] } ]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [claim, locale]
+          properties:
+            claim: { type: string, maxLength: 1000 }
+            locale: { type: string, example: "uk-UA" }
+            max_sources: { type: integer, minimum: 1, maximum: 50, default: 12 }
+            allow_untrusted: { type: boolean, default: false }
+  responses:
+    "200":
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/FactSynthLock_v1_1.yaml#/components/schemas/FactSynthLock'
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema: { $ref: '#/components/schemas/Problem' }
+    "401":
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema: { $ref: '#/components/schemas/Problem' }
+    "429":
+      description: Rate Limited
+      content:
+        application/problem+json:
+          schema: { $ref: '#/components/schemas/Problem' }
+    "500":
+      description: Server Error
+      content:
+        application/problem+json:
+          schema: { $ref: '#/components/schemas/Problem' }

--- a/prompts/factsynth_lock.system.md
+++ b/prompts/factsynth_lock.system.md
@@ -1,0 +1,8 @@
+# FactSynth Verifier — System Prompt (v1.1, Quality-First)
+Mission: produce FACTSYNTH_LOCK v1.1 reports. Use evidence-first synthesis; do not expose chain-of-thought.
+Rules:
+- Apply hard filters, then compute SQS/ESS; use only sources above thresholds.
+- Enforce diversity and recency policies; flag adversarial signals.
+- Output: verdict+confidence, citations (sorted by quality), traceability (high-level), recommendations, quality_report, provenance, policy_snapshot.
+- If coverage < 2 or contradictions strong → manual_review=true.
+- Compatibility Guard: Do not change FactSynth runtime API

--- a/tests/smoke/test_imports.py
+++ b/tests/smoke/test_imports.py
@@ -8,6 +8,6 @@ def test_import_core():
             importlib.import_module(name)
             ok = True
             break
-        except Exception:
+        except ImportError:
             continue
     assert ok, f"Cannot import any of {CANDIDATES}"

--- a/tests/test_glrtpm.py
+++ b/tests/test_glrtpm.py
@@ -3,6 +3,6 @@ from factsynth_ultimate.glrtpm.pipeline import GLRTPMPipeline
 
 def test_glrtpm_roundtrip():
     out = GLRTPMPipeline().run("Test thesis about identity reconstruction.")
-    assert set(["R","I","P","Omega","metrics"]).issubset(out.keys())
+    assert {"R", "I", "P", "Omega", "metrics"}.issubset(out.keys())
     m = out["metrics"]
     assert "coherence" in m and "density" in m and "roles" in m

--- a/tests/test_isr.py
+++ b/tests/test_isr.py
@@ -4,7 +4,7 @@ import pytest
 jax = pytest.importorskip("jax")
 pytest.importorskip("diffrax")
 
-from factsynth_ultimate.isr import (
+from factsynth_ultimate.isr import (  # noqa: E402
     ISRParams,
     dominant_freq,
     estimate_fs,

--- a/tools/prompt_lint.py
+++ b/tools/prompt_lint.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-import sys, re, pathlib, json
+import json
+import pathlib
+import re
+import sys
 
 REQUIRED_AURELIUS = [
     r"Role\s*&\s*Mission",
     r"Capabilities\s*&\s*Non-goals",
-    r"IF–THEN\s*Behavior\s*Rules",
+    r"IF-THEN\s*Behavior\s*Rules",
     r"Style\s*&\s*Safety\s*Guardrails",
     r"KPI\s*&\s*Monitoring",
     r"SPEC_LOCK",
@@ -30,7 +33,10 @@ REQUIRED_NEXUS = [
     r"(NEXUS_LOCK|Output\s*Contract)",
 ]
 FORBIDDEN = [
-    r"\bпочекати\b", r"\bwait\b", r"background (task|work)", r"promise to do later"
+    "\\b(?:\u043f\u043e\u0447\u0435\u043a\u0430\u0442\u0438)\\b",
+    r"\bwait\b",
+    r"background (task|work)",
+    r"promise to do later",
 ]
 API_GUARD = r"Do not change FactSynth runtime API"
 
@@ -78,14 +84,17 @@ def main():
     ok = True
     for p, pats in checks:
         if not p.exists():
-            print(f"[FAIL] Missing file {p}", file=sys.stderr); ok = False; continue
+            print(f"[FAIL] Missing file {p}", file=sys.stderr)
+            ok = False
+            continue
         ok &= must(p, pats)
         ok &= forbid(p, FORBIDDEN)
         ok &= require_api_guard(p)
         ok &= size_check(p)
     g12 = root / "tests" / "golden_12.yaml"
     if not g12.exists():
-        print(f"[FAIL] Missing {g12}", file=sys.stderr); ok = False
+        print(f"[FAIL] Missing {g12}", file=sys.stderr)
+        ok = False
     if not ok:
         sys.exit(1)
     print(json.dumps({"status": "ok"}))

--- a/tools/scripts_calibrate.py
+++ b/tools/scripts_calibrate.py
@@ -6,7 +6,10 @@ Calibrate all scripts/ without changing behavior.
 Idempotent; dry-run by default.
 """
 from __future__ import annotations
-import argparse, os, re, sys, textwrap
+
+import argparse
+import re
+import textwrap
 from pathlib import Path
 
 PY_SHEBANG = "#!/usr/bin/env python3\n"


### PR DESCRIPTION
## Summary
- document FACTSYNTH_LOCK v1.1 output contract with API guard
- add OpenAPI schema and verify endpoint spec referencing contract
- introduce quality policy config and matching system prompt

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19a665dbc8329af680e9400deddf3