### PR TITLE
feat(api): add verify request model

### DIFF
--- a/src/app/api/__init__.py
+++ b/src/app/api/__init__.py
@@ -1,5 +1,6 @@
 """API package for application tests."""
 
-from .verify import api as verify_api, FactSynthLock
+from .verify import fs_lock
+from .verify import router as verify_api
 
-__all__ = ["verify_api", "FactSynthLock"]
+__all__ = ["fs_lock", "verify_api"]

--- a/tests/test_evaluator_api.py
+++ b/tests/test_evaluator_api.py
@@ -37,12 +37,31 @@ def test_evaluate_claim_composes_and_closes():
     assert retriever.closed
 
 
-def test_verify_depends_on_evaluate_and_exposes_lock():
-    assert isinstance(verify_mod.FactSynthLock, type(threading.Lock()))
+def test_verify_uses_retriever_dependency_and_exposes_lock():
+    assert isinstance(verify_mod.fs_lock, type(threading.Lock()))
+    assert inspect.isgeneratorfunction(verify_mod.build_retriever)
 
     sig = inspect.signature(verify_mod.verify)
     params = list(sig.parameters.values())
     assert any(
-        isinstance(p.default, DependsParam) and p.default.dependency is evaluate_claim
+        isinstance(p.default, DependsParam) and p.default.dependency is verify_mod.build_retriever
         for p in params
     )
+
+    class DummyRetriever:
+        def __init__(self):
+            self.closed = False
+
+        def search(self, q):
+            return [(q, 1.0)]
+
+        def close(self):
+            self.closed = True
+
+    req = verify_mod.VerifyRequest(
+        claim="alpha", locale="en", max_sources=5, allow_untrusted=False
+    )
+    retriever = DummyRetriever()
+    result = verify_mod.verify(req, retriever=retriever)
+    assert isinstance(result, verify_mod.FactSynthLock)
+    assert retriever.closed


### PR DESCRIPTION
## Summary
- rename lock export to fs_lock
- add VerifyRequest model and /v1/verify route returning FactSynthLock
- close retriever in dependency generator

## Testing
- `ruff check src/app/api/verify.py src/app/api/__init__.py tests/test_evaluator_api.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1c0c68e008329a781d970eb2a370d