### PR TITLE
Replace lock dataclasses with Pydantic models

### DIFF
--- a/src/app/api/__init__.py
+++ b/src/app/api/__init__.py
@@ -1,5 +1,6 @@
-"""API package for application tests."""
+"""API package exposing the verification endpoint and models."""
 
-from .verify import api as verify_api, FactSynthLock
+from .verify import FactSynthLock
+from .verify import api as verify_api
 
 __all__ = ["verify_api", "FactSynthLock"]

--- a/src/app/api/verify.py
+++ b/src/app/api/verify.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
-from threading import Lock
-
 from fastapi import APIRouter, Depends
 
+from ..core.factsynth_lock import FactSynthLock
 from ..services.evaluator import evaluate_claim
-
-FactSynthLock = Lock()
 
 api = APIRouter()
 
 
-@api.post("/verify")
-def verify(result: dict = Depends(evaluate_claim)) -> dict:  # noqa: B008
+@api.post("/verify", response_model=FactSynthLock)
+def verify(lock: FactSynthLock, _result: dict = Depends(evaluate_claim)) -> FactSynthLock:  # noqa: B008
     """Verify a claim by delegating to :func:`evaluate_claim`.
 
-    The evaluation is resolved via FastAPI's dependency injection. The exported
-    ``FactSynthLock`` can be used by callers wishing to guard concurrent access
-    to evaluation resources.
+    The evaluation is resolved via FastAPI's dependency injection. The supplied
+    ``FactSynthLock`` document is validated and returned.
     """
-    return result
+    return lock

--- a/src/app/core/factsynth_lock.py
+++ b/src/app/core/factsynth_lock.py
@@ -1,30 +1,111 @@
+"""Pydantic models describing a FactSynth lock document.
+
+The original implementation used ``dataclasses``; this module replaces those
+structures with Pydantic models that offer validation and serialization
+support. The models are intentionally permissive - unknown fields are allowed -
+so the schema can evolve without breaking consumers.
+"""
+
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import List
+from typing import Dict, List
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
-@dataclass
-class QualityBlock:
-    """Human-assessed quality information for a document."""
+class Verdict(BaseModel):
+    """Outcome of the claim evaluation."""
 
-    score: float
-    reviewer: str
-    notes: str = ""
+    decision: str = Field(..., description="Assessment of the claim")
+    confidence: float | None = Field(
+        None, description="Confidence score for the assessment"
+    )
 
-
-@dataclass
-class ProvenanceBlock:
-    """Provenance metadata describing the source of a document."""
-
-    source: str
-    url: str | None = None
-    license: str | None = None
+    model_config = ConfigDict(extra="allow")
 
 
-@dataclass
-class FactSynthLock:
-    """Container bundling quality and provenance information."""
+class Citation(BaseModel):
+    """A citation supporting the evaluation."""
 
-    quality: List[QualityBlock] = field(default_factory=list)
-    provenance: List[ProvenanceBlock] = field(default_factory=list)
+    source: str = Field(..., description="Identifier or URL of the source")
+    content: str = Field(..., description="Excerpt taken from the source")
+
+    model_config = ConfigDict(extra="allow")
+
+
+class SourceSynthesis(BaseModel):
+    """Synthesis derived from multiple citations."""
+
+    summary: str = Field(..., description="Summary of the gathered sources")
+    citations: List[Citation] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class Traceability(BaseModel):
+    """Information enabling reproduction of the verdict."""
+
+    steps: List[str] = Field(default_factory=list)
+    sources: List[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class Recommendations(BaseModel):
+    """Follow-up actions suggested by the evaluation."""
+
+    actions: List[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class QualityReport(BaseModel):
+    """Optional quality metrics for the evaluation."""
+
+    metrics: Dict[str, float] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class Provenance(BaseModel):
+    """Optional provenance information for sources."""
+
+    sources: List[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class PolicySnapshot(BaseModel):
+    """Optional snapshot of policies in effect during evaluation."""
+
+    policies: Dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class FactSynthLock(BaseModel):
+    """Container bundling all FactSynth evaluation artefacts."""
+
+    verdict: Verdict
+    source_synthesis: SourceSynthesis
+    traceability: Traceability
+    recommendations: Recommendations
+    quality_report: QualityReport | None = None
+    provenance: Provenance | None = None
+    policy_snapshot: PolicySnapshot | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+__all__ = [
+    "Verdict",
+    "Citation",
+    "SourceSynthesis",
+    "Traceability",
+    "Recommendations",
+    "QualityReport",
+    "Provenance",
+    "PolicySnapshot",
+    "FactSynthLock",
+]
+

--- a/tests/test_evaluator_api.py
+++ b/tests/test_evaluator_api.py
@@ -1,7 +1,7 @@
 import inspect
-import threading
 
 from fastapi.params import Depends as DependsParam
+from pydantic import BaseModel
 
 from app.api import verify as verify_mod
 from app.services.evaluator import evaluate_claim
@@ -37,8 +37,8 @@ def test_evaluate_claim_composes_and_closes():
     assert retriever.closed
 
 
-def test_verify_depends_on_evaluate_and_exposes_lock():
-    assert isinstance(verify_mod.FactSynthLock, type(threading.Lock()))
+def test_verify_depends_on_evaluate_and_exposes_model():
+    assert issubclass(verify_mod.FactSynthLock, BaseModel)
 
     sig = inspect.signature(verify_mod.verify)
     params = list(sig.parameters.values())


### PR DESCRIPTION
## Summary
- refactor `factsynth_lock` to use Pydantic models
- require `verdict`, `source_synthesis`, `traceability`, and `recommendations` in top-level lock model
- wire Pydantic `FactSynthLock` model into `/verify` endpoint and tests

## Testing
- `pre-commit run --files src/app/core/factsynth_lock.py src/app/api/verify.py src/app/api/__init__.py tests/test_evaluator_api.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1c0c8f6088329932b64392535ea0b