### PR TITLE
docs: stabilize Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,37 +1,66 @@
 name: Pages
 on:
+  push:
+    branches: [ "main" ]
   workflow_dispatch:
-  push: { branches: [ main ] }
+
 permissions:
   contents: read
   pages: write
   id-token: write
-concurrency: { group: pages, cancel-in-progress: true }
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
-        with: { python-version: '3.11' }
-      - name: Build MkDocs
-        if: hashFiles('mkdocs.yml') != ''
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: Install docs deps
         run: |
-          python -m pip install -U pip
-          pip install mkdocs mkdocs-material
-          mkdocs build -d site
-      - name: Fallback static
-        if: hashFiles('mkdocs.yml') == ''
+          if [ -f docs/requirements.txt ]; then
+            pip install -r docs/requirements.txt
+          elif [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          else
+            pip install \
+              mkdocs>=1.6 mkdocs-material>=9.5 \
+              pymdown-extensions \
+              mkdocs-redirects mkdocs-minify-plugin \
+              mkdocs-git-revision-date-localized-plugin
+          fi
+      - name: Build MkDocs (strict, fallback non-strict)
         run: |
-          mkdir -p site && cp -r docs/* site/ || true
+          mkdocs build --strict --site-dir site || (echo "Strict build failed → retry non-strict" && mkdocs build --site-dir site)
+      - name: Build ReDoc (OpenAPI)
+        run: |
+          mkdir -p site/openapi
+          if [ -f openapi/openapi.yaml ]; then
+            npx --yes redoc-cli@0.13.23 bundle openapi/openapi.yaml -o site/openapi/index.html
+          else
+            echo "<!doctype html><title>No OpenAPI</title><p>No openapi/openapi.yaml</p>" > site/openapi/index.html
+          fi
+      - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
-        with: { path: site }
+        with:
+          path: site
+
   deploy:
     needs: build
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,9 @@
 
 Welcome to the FactSynth documentation site built with MkDocs and the Material theme.
 
+- **OpenAPI UI:** `/openapi/` (generated during deploy)
+- Repository: https://github.com/neuron7x/FactSynth
+
 ## Contents
 
 - [Production Runbook](prod-runbook.md)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+pymdown-extensions>=10.8
+mkdocs-redirects>=1.2
+mkdocs-minify-plugin>=0.8
+mkdocs-git-revision-date-localized-plugin>=1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,16 @@
 site_name: FactSynth
+site_url: https://neuron7x.github.io/FactSynth/
+repo_url: https://github.com/neuron7x/FactSynth/
+
 theme:
   name: material
+
+plugins:
+  - search
+  - redirects
+  - minify
+  - git-revision-date-localized
+
 nav:
   - Home: index.md
   - Production Runbook: prod-runbook.md


### PR DESCRIPTION
## Summary
- ensure GitHub Pages workflow installs required MkDocs plugins, retries non-strict builds, and bundles OpenAPI docs
- expose site URL, repo URL, and plugin set in MkDocs config
- document OpenAPI endpoint and repository, plus add pinned docs dependencies

## Testing
- `pre-commit run --files docs/requirements.txt mkdocs.yml docs/index.md .github/workflows/pages.yml`
- `pytest -q` *(fails: tests/test_settings_validation.py::test_csv_fields[ip_allowlist] and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c4701fff048329b55ae0319c8bdf3e