### PR TITLE
test: cover invalid language headers

### DIFF
--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -8,13 +8,19 @@ def make_request(header: str) -> Request:
     return Request(scope)
 
 
-def test_choose_language():
+def test_choose_language(httpx_mock):
+    httpx_mock.reset()
     req = make_request("fr, uk;q=0.8, en;q=0.5")
     assert i18n.choose_language(req) == "uk"
     req2 = make_request("")
     assert i18n.choose_language(req2) == i18n.DEFAULT_LANG
+    req3 = make_request("uk;q=bogus, en;q=0.5")
+    assert i18n.choose_language(req3) == i18n.DEFAULT_LANG
+    req4 = make_request("*, fr")
+    assert i18n.choose_language(req4) == i18n.DEFAULT_LANG
 
 
-def test_translate():
+def test_translate(httpx_mock):
+    httpx_mock.reset()
     assert i18n.translate("uk", "forbidden") == "Заборонено"
     assert i18n.translate("xx", "forbidden") == "Forbidden"


### PR DESCRIPTION
## Summary
- expand i18n tests with invalid and wildcard Accept-Language headers
- ensure default language is chosen when header values are malformed or unsupported

## Testing
- `pytest tests/test_i18n.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5198052b0832985dff3d044598659