### PR TITLE
Use schemathesis.openapi.from_dict

### DIFF
--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -11,8 +11,10 @@ OPENAPI_SPEC = {
     "paths": {"/v1/score": {"post": {"responses": {"200": {"description": "OK"}}}}},
 }
 
-schema = schemathesis.from_dict(OPENAPI_SPEC, base_url="http://test")
+schema = schemathesis.openapi.from_dict(OPENAPI_SPEC)
 schema.validate()
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 
 def test_openapi_schema_has_operations() -> None:


### PR DESCRIPTION
## Summary
- call `schemathesis.openapi.from_dict` to load the OpenAPI contract
- relax httpx mock to allow unused responses in the contract test

## Testing
- `pytest tests/test_openapi_contract.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5233c18308329ba8b8ec66dd9f622