### PR TITLE
feat: log strict pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      STRICT_FAIL_FATAL: ${{ vars.STRICT_FAIL_FATAL || 'false' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -40,8 +42,27 @@ jobs:
               mkdocs-git-revision-date-localized-plugin
           fi
       - name: Build MkDocs (strict, fallback non-strict)
+        id: mkdocs
         run: |
-          mkdocs build --strict --site-dir site || (echo "Strict build failed → retry non-strict" && mkdocs build --site-dir site)
+          set +e
+          mkdocs build --strict --site-dir site 2>&1 | tee strict.log
+          strict_exit=${PIPESTATUS[0]}
+          set -e
+          if [ "$strict_exit" -ne 0 ]; then
+            echo "strict_failed=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Strict build failed - retrying non-strict"
+            echo "⚠️ Strict build failed. See strict.log" >> "$GITHUB_STEP_SUMMARY"
+            mkdocs build --site-dir site
+            if [ "$STRICT_FAIL_FATAL" = "true" ]; then
+              exit "$strict_exit"
+            fi
+          fi
+      - name: Upload strict build log
+        if: steps.mkdocs.outputs.strict_failed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: strict-log
+          path: strict.log
       - name: Build ReDoc (OpenAPI)
         run: |
           mkdir -p site/openapi


### PR DESCRIPTION
## Summary
- log MkDocs strict build output and retry non-strict
- upload strict build log artifact and warn in job summary
- allow optional failure when strict mode fails

## Testing
- `act workflow_dispatch -W .github/workflows/pages.yml -j build` *(fails: no Docker)*
- `yamllint .github/workflows/pages.yml` *(warnings about formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68c52340a92c8329b7ca9a502dae1319