### PR TITLE
Add documentation build workflow

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,17 @@
+name: Docs Build
+on:
+  pull_request: { branches: [ main ] }
+permissions: { contents: read }
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with: { python-version: '3.11', cache: 'pip' }
+      - name: Install docs dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r docs/requirements.txt
+      - name: Build docs
+        run: mkdocs build --strict


### PR DESCRIPTION
## Summary
- add CI workflow to build docs on PRs using mkdocs --strict

## Testing
- `pip install -r docs/requirements.txt`
- `mkdocs build --strict`
- `pre-commit run --files .github/workflows/docs-build.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c5233ef6cc8329befdcfccef423ead