### PR TITLE
Ensure Pages workflow uses pinned MkDocs requirements

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,18 +29,7 @@ jobs:
           node-version: "20"
           cache: "npm"
       - name: Install docs deps
-        run: |
-          if [ -f docs/requirements.txt ]; then
-            pip install -r docs/requirements.txt
-          elif [ -f requirements-dev.txt ]; then
-            pip install -r requirements-dev.txt
-          else
-            pip install \
-              mkdocs>=1.6 mkdocs-material>=9.5 \
-              pymdown-extensions \
-              mkdocs-redirects mkdocs-minify-plugin \
-              mkdocs-git-revision-date-localized-plugin
-          fi
+        run: pip install -r docs/requirements.txt
       - name: Build MkDocs (strict, fallback non-strict)
         id: mkdocs
         run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+# Pinned documentation dependencies for MkDocs
 mkdocs==1.6.1
 mkdocs-material==9.6.19
 pymdown-extensions==10.16.1


### PR DESCRIPTION
## Summary
- document MkDocs dependencies in `docs/requirements.txt`
- install documentation requirements in Pages workflow

## Testing
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_68c535b084ec8329b08861c661c654b8