### PR TITLE
Refactor callback URL validation tests

### DIFF
--- a/tests/test_validate_callback_url.py
+++ b/tests/test_validate_callback_url.py
@@ -1,12 +1,19 @@
+import pytest
+from fastapi import HTTPException
+
 from factsynth_ultimate.api.routers import validate_callback_url
 
 
-def test_validate_callback_url_basic():
-    assert validate_callback_url("https://example.com")
-    assert not validate_callback_url("ftp://example.com")
+def test_validate_callback_url_basic(httpx_mock):
+    httpx_mock.reset()
+    assert validate_callback_url("https://example.com") is None
+    with pytest.raises(HTTPException):
+        validate_callback_url("ftp://example.com")
 
 
-def test_validate_callback_url_allowed_hosts(monkeypatch):
+def test_validate_callback_url_allowed_hosts(monkeypatch, httpx_mock):
+    httpx_mock.reset()
     monkeypatch.setenv("CALLBACK_URL_ALLOWED_HOSTS", "a.com,b.com")
-    assert validate_callback_url("https://a.com/path")
-    assert not validate_callback_url("https://c.com")
+    assert validate_callback_url("https://a.com/path") is None
+    with pytest.raises(HTTPException):
+        validate_callback_url("https://c.com")


### PR DESCRIPTION
## Summary
- rewrite callback URL validation tests to assert no exception for valid URLs and expect `HTTPException` for invalid ones
- import FastAPI `HTTPException` and reset `httpx_mock` fixture to satisfy autouse mocks

## Testing
- `pre-commit run --files tests/test_validate_callback_url.py` *(fails: AssertionError: mocked responses not requested in other tests)*
- `SKIP=pytest pre-commit run --files tests/test_validate_callback_url.py`
- `pytest tests/test_validate_callback_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68c53b1db8708329975b9e86666dd004