### PR TITLE
ci: test against multiple python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     env:
       API_KEY: change-me
       RATE_LIMIT_REDIS_URL: redis://test
@@ -22,7 +25,9 @@ jobs:
         with: { node-version: 'lts/*', cache: 'npm' }
 
       - uses: actions/setup-python@v6
-        with: { python-version: '3.11', cache: 'pip' }
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install JS deps
         if: hashFiles('package.json') != ''
@@ -85,7 +90,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ci-failures
+          name: ci-failures-${{ matrix.python-version }}
           if-no-files-found: ignore
           path: |
             **/junit*.xml


### PR DESCRIPTION
## Summary
- run CI on Python 3.10, 3.11, and 3.12
- keep pip cache per Python version
- tag failure artifacts with the Python version

## Testing
- `pre-commit run --files .github/workflows/ci.yml README_CI.md`
- `pytest -q` *(fails: fixture 'httpx_mock' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c53b1e95fc83298f43f277f2aedf84