### PR TITLE
refactor: cache allowed callback hosts

### DIFF
--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -39,6 +39,10 @@ API_KEY = read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY")
 
 ALLOWED_CALLBACK_SCHEMES = {"http", "https"}
 
+ALLOWED_HOSTS = set(
+    filter(None, os.getenv("CALLBACK_URL_ALLOWED_HOSTS", "").split(","))
+)
+
 
 def validate_callback_url(url: str) -> None:
     """Validate that a callback URL uses an allowed scheme and host.
@@ -49,9 +53,6 @@ def validate_callback_url(url: str) -> None:
     Raises:
         HTTPException: If the URL does not use an allowed scheme or host.
     """
-    allowed_hosts = set(
-        filter(None, os.getenv("CALLBACK_URL_ALLOWED_HOSTS", "").split(","))
-    )
     try:
         parsed = urlparse(url)
     except Exception as exc:  # pragma: no cover
@@ -64,7 +65,7 @@ def validate_callback_url(url: str) -> None:
             status_code=HTTPStatus.BAD_REQUEST, detail="Invalid callback URL"
         )
 
-    if allowed_hosts and parsed.hostname not in allowed_hosts:
+    if ALLOWED_HOSTS and parsed.hostname not in ALLOWED_HOSTS:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST, detail="Invalid callback URL"
         )

--- a/tests/test_validate_callback_url.py
+++ b/tests/test_validate_callback_url.py
@@ -1,19 +1,22 @@
+import importlib
+
 import pytest
 from fastapi import HTTPException
 
-from factsynth_ultimate.api.routers import validate_callback_url
 
-
-def test_validate_callback_url_basic(httpx_mock):
+def test_validate_callback_url_basic(monkeypatch, httpx_mock):
     httpx_mock.reset()
-    assert validate_callback_url("https://example.com") is None
+    monkeypatch.delenv("CALLBACK_URL_ALLOWED_HOSTS", raising=False)
+    routers = importlib.reload(importlib.import_module("factsynth_ultimate.api.routers"))
+    assert routers.validate_callback_url("https://example.com") is None
     with pytest.raises(HTTPException):
-        validate_callback_url("ftp://example.com")
+        routers.validate_callback_url("ftp://example.com")
 
 
 def test_validate_callback_url_allowed_hosts(monkeypatch, httpx_mock):
     httpx_mock.reset()
     monkeypatch.setenv("CALLBACK_URL_ALLOWED_HOSTS", "a.com,b.com")
-    assert validate_callback_url("https://a.com/path") is None
+    routers = importlib.reload(importlib.import_module("factsynth_ultimate.api.routers"))
+    assert routers.validate_callback_url("https://a.com/path") is None
     with pytest.raises(HTTPException):
-        validate_callback_url("https://c.com")
+        routers.validate_callback_url("https://c.com")


### PR DESCRIPTION
## Summary
- define `ALLOWED_HOSTS` at import time to avoid repeated env lookups
- reference cached `ALLOWED_HOSTS` in `validate_callback_url`
- reload router module in tests when patching env vars

## Testing
- `pytest tests/test_validate_callback_url.py`
- `ruff check src/factsynth_ultimate/api/routers.py tests/test_validate_callback_url.py --select=E,F`


------
https://chatgpt.com/codex/tasks/task_e_68c53dae46348329978c09bccd4385a9