### PR TITLE
Validate callback URL host

### DIFF
--- a/tests/test_validate_callback_url.py
+++ b/tests/test_validate_callback_url.py
@@ -17,3 +17,9 @@ def test_validate_callback_url_allowed_hosts(monkeypatch, httpx_mock):
     assert validate_callback_url("https://a.com/path") is None
     with pytest.raises(HTTPException):
         validate_callback_url("https://c.com")
+
+
+def test_validate_callback_url_requires_host(httpx_mock):
+    httpx_mock.reset()
+    with pytest.raises(HTTPException):
+        validate_callback_url("https:///missing-host")


### PR DESCRIPTION
## Summary
- ensure callback URLs include a hostname
- add regression test for missing-host URLs

## Testing
- `SKIP=pytest pre-commit run --files src/factsynth_ultimate/api/routers.py tests/test_validate_callback_url.py`
- `pytest tests/test_validate_callback_url.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53f72cd5883298e4169ca6fd9d903