### PR TITLE
Restrict callback URLs when no hosts are whitelisted

### DIFF
--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -49,9 +49,9 @@ def validate_callback_url(url: str) -> None:
     Raises:
         HTTPException: If the URL does not use an allowed scheme or host.
     """
-    allowed_hosts = set(
-        filter(None, os.getenv("CALLBACK_URL_ALLOWED_HOSTS", "").split(","))
-    )
+    allowed_hosts = set(filter(None, os.getenv("CALLBACK_URL_ALLOWED_HOSTS", "").split(",")))
+    if not allowed_hosts:
+        allowed_hosts = {"localhost"}
     try:
         parsed = urlparse(url)
     except Exception as exc:  # pragma: no cover
@@ -60,14 +60,10 @@ def validate_callback_url(url: str) -> None:
         ) from exc
 
     if parsed.scheme not in ALLOWED_CALLBACK_SCHEMES:
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail="Invalid callback URL"
-        )
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid callback URL")
 
-    if allowed_hosts and parsed.hostname not in allowed_hosts:
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail="Invalid callback URL"
-        )
+    if parsed.hostname not in allowed_hosts:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid callback URL")
 
 
 api = APIRouter()
@@ -79,12 +75,14 @@ def version() -> dict[str, str]:
 
     return {"name": "factsynth-ultimate-pro", "version": VERSION}
 
+
 @api.post("/v1/intent_reflector")
 def intent_reflector(req: IntentReq, request: Request) -> dict[str, str]:
     """Reflect user intent into a concise insight string."""
 
     audit_event("intent_reflector", request.client.host if request.client else "unknown")
     return {"insight": reflect_intent(req.intent, req.length)}
+
 
 @api.post("/v1/score")
 def score(
@@ -100,6 +98,7 @@ def score(
         validate_callback_url(req.callback_url)
         background_tasks.add_task(_post_callback, req.callback_url, result)
     return result
+
 
 @api.post("/v1/score/batch")
 def score_batch(
@@ -128,6 +127,7 @@ def generate(req: GenerateReq, request: Request) -> dict[str, dict[str, str]]:
     alphabet = string.ascii_letters + string.digits + " "
     out = "".join(rng.choice(alphabet) for _ in req.text)
     return {"output": {"text": out}}
+
 
 @api.post("/v1/stream")
 async def stream(req: ScoreReq, request: Request) -> StreamingResponse:
@@ -175,6 +175,7 @@ async def stream(req: ScoreReq, request: Request) -> StreamingResponse:
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
 
+
 @api.websocket("/ws/stream")
 async def ws_stream(ws: WebSocket) -> None:
     """Stream tokenization results over WebSocket with API-key auth."""
@@ -192,6 +193,7 @@ async def ws_stream(ws: WebSocket) -> None:
             await ws.send_json({"end": True})
     except WebSocketDisconnect:
         return
+
 
 async def _post_callback(  # noqa: PLR0913
     url: str,
@@ -231,6 +233,7 @@ async def _post_callback(  # noqa: PLR0913
                 delay = min(delay * 2, max_delay)
     if last_err is not None:
         logger.error("Callback failed after %d attempts: %s", attempt_num, last_err)
+
 
 async def _sleep(s: float) -> None:
     """Async sleep exposed for tests and patching."""


### PR DESCRIPTION
## Summary
- default `validate_callback_url` to allow only `localhost` when `CALLBACK_URL_ALLOWED_HOSTS` is empty
- add tests covering localhost default and empty whitelist behavior

## Testing
- `pre-commit run black --files src/factsynth_ultimate/api/routers.py tests/test_validate_callback_url.py`
- `pre-commit run ruff --files src/factsynth_ultimate/api/routers.py tests/test_validate_callback_url.py` *(fails: src/factsynth_ultimate/api/routers.py:133:11 C901 `stream` is too complex (11 > 10))*
- `pytest tests/test_validate_callback_url.py`

------
https://chatgpt.com/codex/tasks/task_e_68c53f754088832989a0417094d720ad