### PR TITLE
Enforce strict FactSynth lock validation

### DIFF
--- a/src/factsynth_ultimate/core/factsynth_lock.py
+++ b/src/factsynth_ultimate/core/factsynth_lock.py
@@ -2,26 +2,33 @@
 
 The original implementation used ``dataclasses``; this module replaces those
 structures with Pydantic models that offer validation and serialization
-support. The models are intentionally permissive - unknown fields are allowed -
-so the schema can evolve without breaking consumers.
+support. Unknown fields are forbidden to ensure the schema is followed
+strictly.
 """
 
 from __future__ import annotations
 
-from typing import Dict, List
+from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class Decision(str, Enum):
+    """Possible outcomes of a claim evaluation."""
+
+    SUPPORTED = "supported"
+    PARTIALLY_SUPPORTED = "partially_supported"
+    REFUTED = "refuted"
+    NOT_PROVABLE = "not_provable"
 
 
 class Verdict(BaseModel):
     """Outcome of the claim evaluation."""
 
-    decision: str = Field(..., description="Assessment of the claim")
-    confidence: float | None = Field(
-        None, description="Confidence score for the assessment"
-    )
+    decision: Decision = Field(..., description="Assessment of the claim")
+    confidence: float | None = Field(None, description="Confidence score for the assessment")
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class Citation(BaseModel):
@@ -30,57 +37,57 @@ class Citation(BaseModel):
     source: str = Field(..., description="Identifier or URL of the source")
     content: str = Field(..., description="Excerpt taken from the source")
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class SourceSynthesis(BaseModel):
     """Synthesis derived from multiple citations."""
 
     summary: str = Field(..., description="Summary of the gathered sources")
-    citations: List[Citation] = Field(default_factory=list)
+    citations: list[Citation] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class Traceability(BaseModel):
     """Information enabling reproduction of the verdict."""
 
-    steps: List[str] = Field(default_factory=list)
-    sources: List[str] = Field(default_factory=list)
+    steps: list[str] = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class Recommendations(BaseModel):
     """Follow-up actions suggested by the evaluation."""
 
-    actions: List[str] = Field(default_factory=list)
+    actions: list[str] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class QualityReport(BaseModel):
     """Optional quality metrics for the evaluation."""
 
-    metrics: Dict[str, float] = Field(default_factory=dict)
+    metrics: dict[str, float] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class Provenance(BaseModel):
     """Optional provenance information for sources."""
 
-    sources: List[str] = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class PolicySnapshot(BaseModel):
     """Optional snapshot of policies in effect during evaluation."""
 
-    policies: Dict[str, str] = Field(default_factory=dict)
+    policies: dict[str, str] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class FactSynthLock(BaseModel):
@@ -94,7 +101,7 @@ class FactSynthLock(BaseModel):
     provenance: Provenance | None = None
     policy_snapshot: PolicySnapshot | None = None
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 __all__ = [
@@ -107,5 +114,5 @@ __all__ = [
     "SourceSynthesis",
     "Traceability",
     "Verdict",
+    "Decision",
 ]
-

--- a/tests/test_factsynth_lock.py
+++ b/tests/test_factsynth_lock.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import ValidationError
+
+from factsynth_ultimate.core.factsynth_lock import FactSynthLock, Verdict
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
+def test_unknown_field_rejected():
+    data = {
+        "verdict": {"decision": "supported"},
+        "source_synthesis": {"summary": "summary"},
+        "traceability": {},
+        "recommendations": {},
+        "unexpected": "value",
+    }
+
+    with pytest.raises(ValidationError):
+        FactSynthLock.model_validate(data)
+
+
+def test_invalid_decision_rejected():
+    with pytest.raises(ValidationError):
+        Verdict.model_validate({"decision": "maybe"})

--- a/tests/test_quality_pipeline.py
+++ b/tests/test_quality_pipeline.py
@@ -1,10 +1,13 @@
 from http import HTTPStatus
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from factsynth_ultimate.api import verify as verify_mod
 from factsynth_ultimate.core.factsynth_lock import FactSynthLock
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 app = FastAPI()
 app.include_router(verify_mod.api)


### PR DESCRIPTION
## Summary
- use a `Decision` enum for `Verdict.decision`
- forbid extra fields across FactSynth lock models
- test rejection of unknown fields and invalid decisions

## Testing
- ⚠️ `pre-commit run --files src/factsynth_ultimate/core/factsynth_lock.py tests/test_factsynth_lock.py tests/test_quality_pipeline.py` (fails: many tests require additional setup)
- ✅ `pre-commit run ruff --files src/factsynth_ultimate/core/factsynth_lock.py tests/test_factsynth_lock.py tests/test_quality_pipeline.py`
- ✅ `pre-commit run black --files src/factsynth_ultimate/core/factsynth_lock.py tests/test_factsynth_lock.py tests/test_quality_pipeline.py`
- ✅ `pytest tests/test_factsynth_lock.py tests/test_quality_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53f788cec832999782f483b326680