### PR TITLE
Block requests when IP allowlist empty

### DIFF
--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import Awaitable, Callable
+import logging
+from collections.abc import Awaitable, Callable
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -11,6 +12,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
 from ..i18n import choose_language, translate
+
+logger = logging.getLogger(__name__)
 
 
 class IPAllowlistMiddleware(BaseHTTPMiddleware):
@@ -25,9 +28,7 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         """Parse CIDR rules and store skip prefixes."""
 
         super().__init__(app)
-        self.networks = [
-            ipaddress.ip_network(c.strip(), strict=False) for c in (cidrs or [])
-        ]
+        self.networks = [ipaddress.ip_network(c.strip(), strict=False) for c in (cidrs or [])]
         self.skip = skip
 
     async def dispatch(
@@ -36,27 +37,34 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         """Check the client IP against the allowlist."""
 
         path = request.url.path
-        if any(path.startswith(s) for s in self.skip) or not self.networks:
+        if any(path.startswith(s) for s in self.skip):
             return await call_next(request)
         ip = request.client.host if request.client else "127.0.0.1"
+
+        def forbidden() -> JSONResponse:
+            lang = choose_language(request)
+            title = translate(lang, "forbidden")
+            detail = f"IP {ip} not allowed"
+            problem = {
+                "type": "about:blank",
+                "title": title,
+                "status": 403,
+                "detail": detail,
+                "trace_id": getattr(request.state, "request_id", ""),
+            }
+            return JSONResponse(
+                problem,
+                status_code=403,
+                media_type="application/problem+json",
+            )
+
+        if not self.networks:
+            logger.warning("IP allowlist empty; blocking request from %s", ip)
+            return forbidden()
         try:
             addr = ipaddress.ip_address(ip)
         except ValueError:
             addr = None
         if addr and any(addr in n for n in self.networks):
             return await call_next(request)
-        lang = choose_language(request)
-        title = translate(lang, "forbidden")
-        detail = f"IP {ip} not allowed"
-        problem = {
-            "type": "about:blank",
-            "title": title,
-            "status": 403,
-            "detail": detail,
-            "trace_id": getattr(request.state, "request_id", ""),
-        }
-        return JSONResponse(
-            problem,
-            status_code=403,
-            media_type="application/problem+json",
-        )
+        return forbidden()


### PR DESCRIPTION
## Summary
- block incoming requests when no CIDR ranges are configured
- test IP allowlist blocking with empty configuration

## Testing
- `SKIP=pytest pre-commit run --files src/factsynth_ultimate/core/ip_allowlist.py tests/test_ip_allowlist.py`
- `pytest tests/test_ip_allowlist.py`


------
https://chatgpt.com/codex/tasks/task_e_68c53f79e078832993ca85546c12f3b3