### PR TITLE
Log NLI classifier exceptions and add fallback test

### DIFF
--- a/src/factsynth_ultimate/services/nli.py
+++ b/src/factsynth_ultimate/services/nli.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable, Optional
+import logging
+from collections.abc import Awaitable, Callable
 
 from ..tokenization import tokenize
+
+logger = logging.getLogger(__name__)
 
 Classifier = Callable[[str, str], Awaitable[float]]
 
@@ -12,7 +15,7 @@ Classifier = Callable[[str, str], Awaitable[float]]
 class NLI:
     """Natural language inference with optional async classifier."""
 
-    def __init__(self, classifier: Optional[Classifier] = None) -> None:
+    def __init__(self, classifier: Classifier | None = None) -> None:
         self.classifier = classifier
 
     async def classify(self, premise: str, hypothesis: str) -> float:
@@ -26,7 +29,8 @@ class NLI:
         if self.classifier is not None:
             try:
                 return await self.classifier(premise, hypothesis)
-            except Exception:  # noqa: BLE001
+            except Exception:
+                logger.exception("classifier_error")
                 pass
         return self._heuristic(premise, hypothesis)
 

--- a/tests/test_nli.py
+++ b/tests/test_nli.py
@@ -6,7 +6,10 @@ EXPECTED_SCORE = 0.42
 THRESHOLD = 0.9
 
 
-def test_nli_uses_async_classifier():
+def test_nli_uses_async_classifier(httpx_mock):
+    httpx_mock.reset()
+    httpx_mock._options.assert_all_responses_were_requested = False
+
     async def classifier(_p: str, _h: str) -> float:
         return EXPECTED_SCORE
 
@@ -15,10 +18,29 @@ def test_nli_uses_async_classifier():
     assert score == EXPECTED_SCORE
 
 
-def test_nli_fallback_on_error():
+def test_nli_fallback_on_error(httpx_mock):
+    httpx_mock.reset()
+    httpx_mock._options.assert_all_responses_were_requested = False
+
     async def failing_classifier(_p: str, _h: str) -> float:
         raise RuntimeError("boom")
 
     nli = NLI(failing_classifier)
+    score = asyncio.run(nli.classify("Cats are animals", "Cats are animals"))
+    assert score > THRESHOLD
+
+
+def test_nli_fallback_on_custom_classifier_error(httpx_mock):
+    httpx_mock.reset()
+    httpx_mock._options.assert_all_responses_were_requested = False
+
+    class CustomError(Exception):
+        pass
+
+    class CustomClassifier:
+        async def __call__(self, _p: str, _h: str) -> float:
+            raise CustomError("boom")
+
+    nli = NLI(CustomClassifier())
     score = asyncio.run(nli.classify("Cats are animals", "Cats are animals"))
     assert score > THRESHOLD


### PR DESCRIPTION
## Summary
- log classifier failures in NLI service before falling back to heuristic
- add regression test using a custom classifier that raises an exception

## Testing
- `SKIP=pytest pre-commit run --files src/factsynth_ultimate/services/nli.py tests/test_nli.py`
- `pytest tests/test_nli.py`


------
https://chatgpt.com/codex/tasks/task_e_68c53f7abb588329a87ed8f3a5a77507