### PR TITLE
Harden callback validation and lock schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+            pyproject.toml
 
       - name: Install JS deps
         if: hashFiles('package.json') != ''

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ structured logs, and tracing hooks.
 - Extractive generation — handled through FastAPI endpoints.
 - Streaming responses — Server-Sent Events and WebSocket support.
 - Security controls — API key header and optional IP allowlist.
+- Safe callback validation — URLs must use approved schemes and hostnames.
 - Rate limiting — sliding window limits per client.
 - Problem+JSON — RFC 9457 compliant error payloads.
 - Observability — Prometheus metrics, structured logs, and tracing hooks.

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ markers =
     anyio: async tests
     smoke: stream smoke tests
     slow: lengthy streams/benchmarks
+    httpx_mock: control HTTPX mock behavior

--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 API_KEY = read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY")
 
 ALLOWED_CALLBACK_SCHEMES = {"http", "https"}
+ALLOWED_HOSTS = set(filter(None, os.getenv("CALLBACK_URL_ALLOWED_HOSTS", "").split(",")))
 
 
 def validate_callback_url(url: str) -> None:
@@ -49,7 +50,6 @@ def validate_callback_url(url: str) -> None:
     Raises:
         HTTPException: If the URL does not use an allowed scheme or host.
     """
-    allowed_hosts = set(filter(None, os.getenv("CALLBACK_URL_ALLOWED_HOSTS", "").split(",")))
     try:
         parsed = urlparse(url)
     except Exception as exc:  # pragma: no cover
@@ -63,7 +63,7 @@ def validate_callback_url(url: str) -> None:
     if parsed.scheme not in ALLOWED_CALLBACK_SCHEMES:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid callback URL")
 
-    if allowed_hosts and parsed.hostname not in allowed_hosts:
+    if not ALLOWED_HOSTS or parsed.hostname not in ALLOWED_HOSTS:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid callback URL")
 
 

--- a/src/factsynth_ultimate/core/factsynth_lock.py
+++ b/src/factsynth_ultimate/core/factsynth_lock.py
@@ -2,26 +2,32 @@
 
 The original implementation used ``dataclasses``; this module replaces those
 structures with Pydantic models that offer validation and serialization
-support. The models are intentionally permissive - unknown fields are allowed -
-so the schema can evolve without breaking consumers.
+support. Unknown fields are forbidden to ensure the schema is followed strictly.
 """
 
 from __future__ import annotations
 
-from typing import Dict, List
+from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class Decision(str, Enum):
+    """Possible outcomes of a claim evaluation."""
+
+    SUPPORTED = "supported"
+    PARTIALLY_SUPPORTED = "partially_supported"
+    REFUTED = "refuted"
+    NOT_PROVABLE = "not_provable"
 
 
 class Verdict(BaseModel):
     """Outcome of the claim evaluation."""
 
-    decision: str = Field(..., description="Assessment of the claim")
-    confidence: float | None = Field(
-        None, description="Confidence score for the assessment"
-    )
+    decision: Decision = Field(..., description="Assessment of the claim")
+    confidence: float | None = Field(None, description="Confidence score for the assessment")
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class Citation(BaseModel):
@@ -30,57 +36,57 @@ class Citation(BaseModel):
     source: str = Field(..., description="Identifier or URL of the source")
     content: str = Field(..., description="Excerpt taken from the source")
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class SourceSynthesis(BaseModel):
     """Synthesis derived from multiple citations."""
 
     summary: str = Field(..., description="Summary of the gathered sources")
-    citations: List[Citation] = Field(default_factory=list)
+    citations: list[Citation] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class Traceability(BaseModel):
     """Information enabling reproduction of the verdict."""
 
-    steps: List[str] = Field(default_factory=list)
-    sources: List[str] = Field(default_factory=list)
+    steps: list[str] = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class Recommendations(BaseModel):
     """Follow-up actions suggested by the evaluation."""
 
-    actions: List[str] = Field(default_factory=list)
+    actions: list[str] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class QualityReport(BaseModel):
     """Optional quality metrics for the evaluation."""
 
-    metrics: Dict[str, float] = Field(default_factory=dict)
+    metrics: dict[str, float] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class Provenance(BaseModel):
     """Optional provenance information for sources."""
 
-    sources: List[str] = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class PolicySnapshot(BaseModel):
     """Optional snapshot of policies in effect during evaluation."""
 
-    policies: Dict[str, str] = Field(default_factory=dict)
+    policies: dict[str, str] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class FactSynthLock(BaseModel):
@@ -94,7 +100,7 @@ class FactSynthLock(BaseModel):
     provenance: Provenance | None = None
     policy_snapshot: PolicySnapshot | None = None
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 __all__ = [
@@ -107,5 +113,5 @@ __all__ = [
     "SourceSynthesis",
     "Traceability",
     "Verdict",
+    "Decision",
 ]
-

--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import Awaitable, Callable
+import logging
+from collections.abc import Awaitable, Callable
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -11,6 +12,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
 from ..i18n import choose_language, translate
+
+logger = logging.getLogger(__name__)
 
 
 class IPAllowlistMiddleware(BaseHTTPMiddleware):
@@ -25,9 +28,7 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         """Parse CIDR rules and store skip prefixes."""
 
         super().__init__(app)
-        self.networks = [
-            ipaddress.ip_network(c.strip(), strict=False) for c in (cidrs or [])
-        ]
+        self.networks = [ipaddress.ip_network(c.strip(), strict=False) for c in (cidrs or [])]
         self.skip = skip
 
     async def dispatch(
@@ -36,27 +37,34 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         """Check the client IP against the allowlist."""
 
         path = request.url.path
-        if any(path.startswith(s) for s in self.skip) or not self.networks:
+        if any(path.startswith(s) for s in self.skip):
             return await call_next(request)
         ip = request.client.host if request.client else "127.0.0.1"
+
+        def forbidden() -> JSONResponse:
+            lang = choose_language(request)
+            title = translate(lang, "forbidden")
+            detail = f"IP {ip} not allowed"
+            problem = {
+                "type": "about:blank",
+                "title": title,
+                "status": 403,
+                "detail": detail,
+                "trace_id": getattr(request.state, "request_id", ""),
+            }
+            return JSONResponse(
+                problem,
+                status_code=403,
+                media_type="application/problem+json",
+            )
+
+        if not self.networks:
+            logger.warning("IP allowlist empty; blocking request from %s", ip)
+            return forbidden()
         try:
             addr = ipaddress.ip_address(ip)
         except ValueError:
             addr = None
         if addr and any(addr in n for n in self.networks):
             return await call_next(request)
-        lang = choose_language(request)
-        title = translate(lang, "forbidden")
-        detail = f"IP {ip} not allowed"
-        problem = {
-            "type": "about:blank",
-            "title": title,
-            "status": 403,
-            "detail": detail,
-            "trace_id": getattr(request.state, "request_id", ""),
-        }
-        return JSONResponse(
-            problem,
-            status_code=403,
-            media_type="application/problem+json",
-        )
+        return forbidden()

--- a/src/factsynth_ultimate/services/nli.py
+++ b/src/factsynth_ultimate/services/nli.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable, Optional
+import logging
+from collections.abc import Awaitable, Callable
 
 from ..tokenization import tokenize
+
+logger = logging.getLogger(__name__)
 
 Classifier = Callable[[str, str], Awaitable[float]]
 
@@ -12,7 +15,7 @@ Classifier = Callable[[str, str], Awaitable[float]]
 class NLI:
     """Natural language inference with optional async classifier."""
 
-    def __init__(self, classifier: Optional[Classifier] = None) -> None:
+    def __init__(self, classifier: Classifier | None = None) -> None:
         self.classifier = classifier
 
     async def classify(self, premise: str, hypothesis: str) -> float:
@@ -26,8 +29,8 @@ class NLI:
         if self.classifier is not None:
             try:
                 return await self.classifier(premise, hypothesis)
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception:
+                logger.exception("classifier_error")
         return self._heuristic(premise, hypothesis)
 
     def _heuristic(self, premise: str, hypothesis: str) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ async def api_stub():
 def _stub_external_api(httpx_mock):
     """Stub external HTTP calls so tests remain offline."""
 
-    httpx_mock.reset(assert_all_responses_were_requested=False)
+    httpx_mock.reset()
 
     def handler(request):
         path = request.url.path
@@ -98,4 +98,4 @@ def _stub_external_api(httpx_mock):
 
     httpx_mock.add_callback(handler)
     yield
-    httpx_mock.reset(assert_all_responses_were_requested=False)
+    httpx_mock.reset()

--- a/tests/test_callback_validation.py
+++ b/tests/test_callback_validation.py
@@ -1,43 +1,58 @@
+import importlib
 import os
 from http import HTTPStatus
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from factsynth_ultimate.app import create_app
+import factsynth_ultimate.app as app_module
+from factsynth_ultimate.api import routers
 
 
-def test_invalid_callback_scheme() -> None:
+def test_invalid_callback_scheme(httpx_mock) -> None:
+    httpx_mock.reset()
     env = {"API_KEY": "secret", "CALLBACK_URL_ALLOWED_HOSTS": "example.com"}
-    with patch.dict(os.environ, env), TestClient(create_app()) as client:
-        r = client.post(
-            "/v1/score",
-            headers={"x-api-key": "secret"},
-            json={"text": "x", "callback_url": "ftp://example.com/cb"},
-        )
-        assert r.status_code == HTTPStatus.BAD_REQUEST
-        assert r.json()["detail"] == "Invalid callback URL"
+    with patch.dict(os.environ, env):
+        importlib.reload(routers)
+        importlib.reload(app_module)
+        with TestClient(app_module.create_app()) as client:
+            r = client.post(
+                "/v1/score",
+                headers={"x-api-key": "secret"},
+                json={"text": "x", "callback_url": "ftp://example.com/cb"},
+            )
+            assert r.status_code == HTTPStatus.BAD_REQUEST
+            assert r.json()["detail"] == "Invalid callback URL"
 
 
-def test_invalid_callback_host() -> None:
+def test_invalid_callback_host(httpx_mock) -> None:
+    httpx_mock.reset()
     env = {"API_KEY": "secret", "CALLBACK_URL_ALLOWED_HOSTS": "example.com"}
-    with patch.dict(os.environ, env), TestClient(create_app()) as client:
-        r = client.post(
-            "/v1/score",
-            headers={"x-api-key": "secret"},
-            json={"text": "x", "callback_url": "https://evil.com/cb"},
-        )
-        assert r.status_code == HTTPStatus.BAD_REQUEST
-        assert r.json()["detail"] == "Invalid callback URL"
+    with patch.dict(os.environ, env):
+        importlib.reload(routers)
+        importlib.reload(app_module)
+        with TestClient(app_module.create_app()) as client:
+            r = client.post(
+                "/v1/score",
+                headers={"x-api-key": "secret"},
+                json={"text": "x", "callback_url": "https://evil.com/cb"},
+            )
+            assert r.status_code == HTTPStatus.BAD_REQUEST
+            assert r.json()["detail"] == "Invalid callback URL"
 
 
-def test_valid_callback_url() -> None:
+def test_valid_callback_url(httpx_mock) -> None:
+    httpx_mock.reset()
+    httpx_mock.add_response(url="https://example.com/cb", status_code=200)
     env = {"API_KEY": "secret", "CALLBACK_URL_ALLOWED_HOSTS": "example.com"}
-    with patch.dict(os.environ, env), TestClient(create_app()) as client:
-        r = client.post(
-            "/v1/score",
-            headers={"x-api-key": "secret"},
-            json={"text": "x", "callback_url": "https://example.com/cb"},
-        )
-        assert r.status_code == HTTPStatus.OK
-        assert "score" in r.json()
+    with patch.dict(os.environ, env):
+        importlib.reload(routers)
+        importlib.reload(app_module)
+        with TestClient(app_module.create_app()) as client:
+            r = client.post(
+                "/v1/score",
+                headers={"x-api-key": "secret"},
+                json={"text": "x", "callback_url": "https://example.com/cb"},
+            )
+            assert r.status_code == HTTPStatus.OK
+            assert "score" in r.json()

--- a/tests/test_factsynth_lock.py
+++ b/tests/test_factsynth_lock.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import ValidationError
+
+from factsynth_ultimate.core.factsynth_lock import FactSynthLock, Verdict
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
+def test_unknown_field_rejected():
+    data = {
+        "verdict": {"decision": "supported"},
+        "source_synthesis": {"summary": "summary"},
+        "traceability": {},
+        "recommendations": {},
+        "unexpected": "value",
+    }
+
+    with pytest.raises(ValidationError):
+        FactSynthLock.model_validate(data)
+
+
+def test_invalid_decision_rejected():
+    with pytest.raises(ValidationError):
+        Verdict.model_validate({"decision": "maybe"})

--- a/tests/test_factsynth_lock_contract.py
+++ b/tests/test_factsynth_lock_contract.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from factsynth_ultimate.core.factsynth_lock import (
+    FactSynthLock,
+    Recommendations,
+    SourceSynthesis,
+    Traceability,
+    Verdict,
+)
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
+def test_verdict_enforces_enum_and_no_extra():
+    with pytest.raises(ValidationError):
+        Verdict(decision="maybe")
+    with pytest.raises(ValidationError):
+        Verdict(decision="supported", unknown="field")
+
+
+def test_lock_rejects_unknown_fields():
+    v = Verdict(decision="supported")
+    ss = SourceSynthesis(summary="s")
+    tr = Traceability()
+    rec = Recommendations()
+    with pytest.raises(ValidationError):
+        FactSynthLock(
+            verdict=v,
+            source_synthesis=ss,
+            traceability=tr,
+            recommendations=rec,
+            unknown="field",
+        )

--- a/tests/test_nli.py
+++ b/tests/test_nli.py
@@ -6,7 +6,9 @@ EXPECTED_SCORE = 0.42
 THRESHOLD = 0.9
 
 
-def test_nli_uses_async_classifier():
+def test_nli_uses_async_classifier(httpx_mock):
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+
     async def classifier(_p: str, _h: str) -> float:
         return EXPECTED_SCORE
 
@@ -15,10 +17,27 @@ def test_nli_uses_async_classifier():
     assert score == EXPECTED_SCORE
 
 
-def test_nli_fallback_on_error():
+def test_nli_fallback_on_error(httpx_mock):
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+
     async def failing_classifier(_p: str, _h: str) -> float:
         raise RuntimeError("boom")
 
     nli = NLI(failing_classifier)
+    score = asyncio.run(nli.classify("Cats are animals", "Cats are animals"))
+    assert score > THRESHOLD
+
+
+def test_nli_fallback_on_custom_classifier_error(httpx_mock):
+    httpx_mock.reset(assert_all_responses_were_requested=False)
+
+    class CustomError(Exception):
+        pass
+
+    class CustomClassifier:
+        async def __call__(self, _p: str, _h: str) -> float:
+            raise CustomError("boom")
+
+    nli = NLI(CustomClassifier())
     score = asyncio.run(nli.classify("Cats are animals", "Cats are animals"))
     assert score > THRESHOLD

--- a/tests/test_nli.py
+++ b/tests/test_nli.py
@@ -7,7 +7,7 @@ THRESHOLD = 0.9
 
 
 def test_nli_uses_async_classifier(httpx_mock):
-    httpx_mock.reset(assert_all_responses_were_requested=False)
+    httpx_mock.reset()
 
     async def classifier(_p: str, _h: str) -> float:
         return EXPECTED_SCORE
@@ -18,7 +18,7 @@ def test_nli_uses_async_classifier(httpx_mock):
 
 
 def test_nli_fallback_on_error(httpx_mock):
-    httpx_mock.reset(assert_all_responses_were_requested=False)
+    httpx_mock.reset()
 
     async def failing_classifier(_p: str, _h: str) -> float:
         raise RuntimeError("boom")
@@ -29,7 +29,7 @@ def test_nli_fallback_on_error(httpx_mock):
 
 
 def test_nli_fallback_on_custom_classifier_error(httpx_mock):
-    httpx_mock.reset(assert_all_responses_were_requested=False)
+    httpx_mock.reset()
 
     class CustomError(Exception):
         pass

--- a/tests/test_quality_pipeline.py
+++ b/tests/test_quality_pipeline.py
@@ -15,7 +15,7 @@ client = TestClient(app)
 
 
 def test_quality_pipeline_verify_returns_lock(httpx_mock):
-    httpx_mock.reset(assert_all_responses_were_requested=False)
+    httpx_mock.reset()
     payload = {
         "claim": "The earth orbits the sun",
         "lock": {

--- a/tests/test_quality_pipeline.py
+++ b/tests/test_quality_pipeline.py
@@ -1,17 +1,21 @@
 from http import HTTPStatus
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from factsynth_ultimate.api import verify as verify_mod
 from factsynth_ultimate.core.factsynth_lock import FactSynthLock
 
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
 app = FastAPI()
 app.include_router(verify_mod.api)
 client = TestClient(app)
 
 
-def test_quality_pipeline_verify_returns_lock():
+def test_quality_pipeline_verify_returns_lock(httpx_mock):
+    httpx_mock.reset(assert_all_responses_were_requested=False)
     payload = {
         "claim": "The earth orbits the sun",
         "lock": {

--- a/tests/test_validate_callback_url.py
+++ b/tests/test_validate_callback_url.py
@@ -1,25 +1,40 @@
+import importlib
+
 import pytest
 from fastapi import HTTPException
 
-from factsynth_ultimate.api.routers import validate_callback_url
+from factsynth_ultimate.api import routers
+
+# Allow unrequested HTTPX mocks registered by the autouse fixture.
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 
-def test_validate_callback_url_basic(httpx_mock):
-    httpx_mock.reset()
-    assert validate_callback_url("https://example.com") is None
+def reload_routers(monkeypatch, hosts: str):
+    monkeypatch.setenv("CALLBACK_URL_ALLOWED_HOSTS", hosts)
+    return importlib.reload(routers)
+
+
+def test_validate_callback_url_basic(monkeypatch):
+    module = reload_routers(monkeypatch, "example.com")
+    assert module.validate_callback_url("https://example.com") is None
     with pytest.raises(HTTPException):
-        validate_callback_url("ftp://example.com")
+        module.validate_callback_url("ftp://example.com")
 
 
-def test_validate_callback_url_allowed_hosts(monkeypatch, httpx_mock):
-    httpx_mock.reset()
-    monkeypatch.setenv("CALLBACK_URL_ALLOWED_HOSTS", "a.com,b.com")
-    assert validate_callback_url("https://a.com/path") is None
+def test_validate_callback_url_allowed_hosts(monkeypatch):
+    module = reload_routers(monkeypatch, "a.com,b.com")
+    assert module.validate_callback_url("https://a.com/path") is None
     with pytest.raises(HTTPException):
-        validate_callback_url("https://c.com")
+        module.validate_callback_url("https://c.com")
 
 
-def test_validate_callback_url_missing_host(httpx_mock):
-    httpx_mock.reset()
+def test_validate_callback_url_missing_host(monkeypatch):
+    module = reload_routers(monkeypatch, "example.com")
     with pytest.raises(HTTPException):
-        validate_callback_url("https:///path")
+        module.validate_callback_url("https:///path")
+
+
+def test_validate_callback_url_without_whitelist(monkeypatch):
+    module = reload_routers(monkeypatch, "")
+    with pytest.raises(HTTPException):
+        module.validate_callback_url("https://example.com")


### PR DESCRIPTION
## Summary
- merge latest upstream changes resolving conflicts
- enforce strict FactSynth lock schema with explicit decision enum
- block requests when IP allowlist is empty and log classifier failures
- refresh tests and fixtures for updated pytest-httpx
- document new callback URL safeguards

## Testing
- `pytest tests/test_validate_callback_url.py tests/test_ip_allowlist.py tests/test_factsynth_lock.py tests/test_factsynth_lock_contract.py -q`
- `SKIP=pytest pre-commit run --files .github/workflows/ci.yml src/factsynth_ultimate/api/routers.py src/factsynth_ultimate/core/factsynth_lock.py src/factsynth_ultimate/core/ip_allowlist.py src/factsynth_ultimate/services/nli.py tests/test_callback_validation.py tests/test_ip_allowlist.py tests/test_validate_callback_url.py tests/test_factsynth_lock.py tests/test_factsynth_lock_contract.py`
- `SKIP=pytest pre-commit run --files README.md`


------
https://chatgpt.com/codex/tasks/task_e_68c53a92e87c8329b788c90870f4a1aa