### PR TITLE
Refine callback URL validation

### DIFF
--- a/tests/test_callback_validation.py
+++ b/tests/test_callback_validation.py
@@ -2,9 +2,13 @@ import os
 from http import HTTPStatus
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from factsynth_ultimate.app import create_app
+
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 
 def test_invalid_callback_scheme() -> None:
@@ -16,7 +20,7 @@ def test_invalid_callback_scheme() -> None:
             json={"text": "x", "callback_url": "ftp://example.com/cb"},
         )
         assert r.status_code == HTTPStatus.BAD_REQUEST
-        assert r.json()["detail"] == "Invalid callback URL"
+        assert r.json()["detail"] == "Invalid callback URL scheme"
 
 
 def test_invalid_callback_host() -> None:
@@ -28,7 +32,7 @@ def test_invalid_callback_host() -> None:
             json={"text": "x", "callback_url": "https://evil.com/cb"},
         )
         assert r.status_code == HTTPStatus.BAD_REQUEST
-        assert r.json()["detail"] == "Invalid callback URL"
+        assert r.json()["detail"] == "Invalid callback URL host"
 
 
 def test_valid_callback_url() -> None:

--- a/tests/test_validate_callback_url.py
+++ b/tests/test_validate_callback_url.py
@@ -4,22 +4,39 @@ from fastapi import HTTPException
 from factsynth_ultimate.api.routers import validate_callback_url
 
 
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
 def test_validate_callback_url_basic(httpx_mock):
     httpx_mock.reset()
     validate_callback_url("https://example.com")
-    with pytest.raises(HTTPException):
+    with pytest.raises(HTTPException) as exc:
         validate_callback_url("ftp://example.com")
+    assert exc.value.detail == "Invalid callback URL scheme"
 
 
 def test_validate_callback_url_allowed_hosts(monkeypatch, httpx_mock):
     httpx_mock.reset()
     monkeypatch.setenv("CALLBACK_URL_ALLOWED_HOSTS", "a.com,b.com")
     validate_callback_url("https://a.com/path")
-    with pytest.raises(HTTPException):
+    with pytest.raises(HTTPException) as exc:
         validate_callback_url("https://c.com")
+    assert exc.value.detail == "Invalid callback URL host"
 
 
 def test_validate_callback_url_missing_host(httpx_mock):
     httpx_mock.reset()
-    with pytest.raises(HTTPException):
+    with pytest.raises(HTTPException) as exc:
         validate_callback_url("https:///path")
+    assert exc.value.detail == "Invalid callback URL host"
+
+
+def test_validate_callback_url_dynamic_allowlist(monkeypatch, httpx_mock):
+    httpx_mock.reset()
+    monkeypatch.setenv("CALLBACK_URL_ALLOWED_HOSTS", "a.com")
+    validate_callback_url("https://a.com/path")
+    monkeypatch.setenv("CALLBACK_URL_ALLOWED_HOSTS", "b.com")
+    with pytest.raises(HTTPException) as exc:
+        validate_callback_url("https://a.com/path")
+    assert exc.value.detail == "Invalid callback URL host"
+    validate_callback_url("https://b.com/path")


### PR DESCRIPTION
## Summary
- add runtime getter for callback host allowlist
- provide explicit scheme vs host error messages
- test dynamic allowlist and message details

## Testing
- `pytest tests/test_validate_callback_url.py tests/test_callback_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68c556cf9b2483299a68129bbdf2caf8