### PR TITLE
refactor: enum-based GLRTPM pipeline

### DIFF
--- a/src/factsynth_ultimate/glrtpm/pipeline.py
+++ b/src/factsynth_ultimate/glrtpm/pipeline.py
@@ -2,18 +2,87 @@
 """Simple pipeline orchestrating GLRTPM role interactions."""
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List
+from enum import Enum
+from typing import Any
 
 from .metrics import cluster_density, compute_coherence, role_contribution
 from .roles import Aesthete, Critic, Integrator, Observer, Rationalist
+
+
+class GLRTPMStep(str, Enum):
+    """Enumeration of supported pipeline steps."""
+
+    R = "R"
+    I = "I"  # noqa: E741
+    P = "P"
+    Omega = "Omega"
+
+
+def handle_r(thesis: str, _: dict[str, str]) -> str:
+    """Return critic response for thesis."""
+
+    return Critic().respond(thesis)
+
+
+def handle_i(thesis: str, _: dict[str, str]) -> str:
+    """Return combined rationalist and aesthete perspectives."""
+
+    return " | ".join([Rationalist().respond(thesis), Aesthete().respond(thesis)])
+
+
+def handle_p(thesis: str, results: dict[str, str]) -> str:
+    """Project thesis and counter arguments into a meta representation."""
+
+    return "[Meta-Projection] Nodes: " + json.dumps(
+        {
+            "thesis": f"{thesis[:64]}...",
+            "counter": f"{results.get('R', '')[:64]}...",
+        }
+    )
+
+
+def handle_omega(thesis: str, _: dict[str, str]) -> str:
+    """Return integrator synthesis and observer audit."""
+
+    return Integrator().respond(thesis) + " | " + Observer().respond(thesis)
+
+
+STEP_HANDLERS: dict[GLRTPMStep, Callable[[str, dict[str, str]], str]] = {
+    GLRTPMStep.R: handle_r,
+    GLRTPMStep.I: handle_i,
+    GLRTPMStep.P: handle_p,
+    GLRTPMStep.Omega: handle_omega,
+}
 
 
 @dataclass
 class GLRTPMConfig:
     """Configuration specifying which GLRTPM steps to execute."""
 
-    steps: List[str] = field(default_factory=lambda: ["R", "I", "P", "Omega"])
+    steps: list[GLRTPMStep | str] = field(
+        default_factory=lambda: [
+            GLRTPMStep.R,
+            GLRTPMStep.I,
+            GLRTPMStep.P,
+            GLRTPMStep.Omega,
+        ]
+    )
+
+    def __post_init__(self) -> None:
+        """Validate and normalize *steps* to ``GLRTPMStep`` members."""
+
+        validated: list[GLRTPMStep] = []
+        for step in self.steps:
+            if isinstance(step, GLRTPMStep):
+                validated.append(step)
+            else:
+                try:
+                    validated.append(GLRTPMStep(step))
+                except ValueError as exc:  # pragma: no cover - defensive
+                    raise ValueError(f"Unknown GLRTPM step: {step}") from exc
+        self.steps = validated
 
 @dataclass
 class GLRTPMPipeline:
@@ -21,33 +90,14 @@ class GLRTPMPipeline:
 
     config: GLRTPMConfig = field(default_factory=GLRTPMConfig)
 
-    def run(self, thesis: str) -> Dict[str, Any]:
+    def run(self, thesis: str) -> dict[str, Any]:
         """Execute all configured steps for *thesis* and compute metrics."""
 
-        handlers: Dict[str, Callable[[str, Dict[str, str]], str]] = {
-            "R": lambda t, _: Critic().respond(t),
-            "I": lambda t, _: " | ".join(
-                [Rationalist().respond(t), Aesthete().respond(t)]
-            ),
-            "P": lambda t, res: (
-                "[Meta-Projection] Nodes: "
-                + json.dumps(
-                    {
-                        "thesis": f"{t[:64]}...",
-                        "counter": f"{res.get('R', '')[:64]}...",
-                    }
-                )
-            ),
-            "Omega": lambda t, _: Integrator().respond(t)
-            + " | "
-            + Observer().respond(t),
-        }
-
-        results: Dict[str, str] = {}
+        results: dict[str, str] = {}
         for step in self.config.steps:
-            handler = handlers.get(step)
+            handler = STEP_HANDLERS.get(step)
             if handler:
-                results[step] = handler(thesis, results)
+                results[step.value] = handler(thesis, results)
 
         metrics = {
             "coherence": compute_coherence(thesis, *results.values()),

--- a/tests/test_api_glrtpm_endpoint.py
+++ b/tests/test_api_glrtpm_endpoint.py
@@ -1,9 +1,12 @@
 from http import HTTPStatus
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from factsynth_ultimate.api_glrtpm import GLRTPMPipeline, router
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 
 def test_glrtpm_api(monkeypatch):

--- a/tests/test_glrtpm.py
+++ b/tests/test_glrtpm.py
@@ -1,4 +1,8 @@
-from factsynth_ultimate.glrtpm.pipeline import GLRTPMPipeline
+import pytest
+
+from factsynth_ultimate.glrtpm.pipeline import GLRTPMConfig, GLRTPMPipeline
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 
 def test_glrtpm_roundtrip():
@@ -6,3 +10,8 @@ def test_glrtpm_roundtrip():
     assert {"R", "I", "P", "Omega", "metrics"}.issubset(out.keys())
     m = out["metrics"]
     assert {"coherence", "density", "roles"}.issubset(m)
+
+
+def test_unknown_step_raises_error():
+    with pytest.raises(ValueError, match="Unknown GLRTPM step: X"):
+        GLRTPMPipeline(GLRTPMConfig(steps=["X"]))

--- a/tests/test_glrtpm_roles.py
+++ b/tests/test_glrtpm_roles.py
@@ -1,3 +1,5 @@
+import pytest
+
 from factsynth_ultimate.glrtpm.roles import (
     Aesthete,
     Critic,
@@ -5,6 +7,8 @@ from factsynth_ultimate.glrtpm.roles import (
     Observer,
     Rationalist,
 )
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 
 def test_roles_respond_include_name_and_thesis():


### PR DESCRIPTION
## Summary
- replace lambda handler mapping with named functions
- add `GLRTPMStep` enum and validate config steps
- test unknown step identifiers trigger clear errors

## Testing
- `ruff check src/factsynth_ultimate/glrtpm/pipeline.py tests/test_glrtpm.py tests/test_glrtpm_roles.py tests/test_api_glrtpm_endpoint.py`
- `pytest tests/test_glrtpm.py tests/test_glrtpm_roles.py tests/test_api_glrtpm_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68c556d3417083298175f22e7702edf3