### PR TITLE
docs: document pip-compile workflow and validate requirements-dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,13 @@ repos:
         language: system
         pass_filenames: false
         types: [python]
+  - repo: https://github.com/jazzband/pip-tools
+    rev: v7.5.0
+    hooks:
+      - id: pip-compile
+        name: pip-compile requirements-dev
+        files: ^(pyproject\.toml|requirements-dev\.txt)$
+        args: ["--extra=dev", "--output-file=requirements-dev.txt", "pyproject.toml"]
   - repo: https://github.com/psf/black
     rev: 24.8.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ git clone https://github.com/neuron7x/FactSynth.git
 cd FactSynth
 python -m venv .venv && source .venv/bin/activate
 pip install -U pip && pip install -r requirements.lock && pip install -e .[dev]
-# Or generate a pinned requirements-dev.txt:
+# Or generate a pinned requirements-dev.txt via pip-compile:
 # scripts/update_dev_requirements.sh && pip install -r requirements-dev.txt
 uvicorn factsynth_ultimate.app:app --reload
 ```
@@ -99,13 +99,16 @@ Set up a local development environment:
    pip install -U pip
    pip install -r requirements.lock && pip install -e .[dev]
    # Optional: scripts/update_dev_requirements.sh && pip install -r requirements-dev.txt
+   # (the script wraps pip-compile to regenerate requirements-dev.txt from pyproject.toml)
    ```
 
 `requests` powers the contract tests while `PyYAML` supports schema
 validation; these and other development dependencies are managed in
 `pyproject.toml` under the `dev` extra. Run `pip install -e .[dev]` or
 generate `requirements-dev.txt` with `scripts/update_dev_requirements.sh`
-to install them.
+(which invokes `pip-compile`) to install them. A pre-commit hook runs
+`pip-compile` to keep `requirements-dev.txt` in sync with
+`pyproject.toml`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- clarify that `requirements-dev.txt` is generated via `pip-compile`
- check `requirements-dev.txt` freshness with a new pre-commit hook

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml pyproject.toml requirements-dev.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c556d4b0708329964f7b15c9475abc