### PR TITLE
Log unparseable IP and test warning

### DIFF
--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -64,7 +64,7 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         try:
             addr = ipaddress.ip_address(ip)
         except ValueError:
-            logger.warning("Invalid IP address %s", ip)
+            logger.warning("Unparseable IP address %s", ip)
             addr = None
         if addr and any(addr in n for n in self.networks):
             return await call_next(request)

--- a/tests/test_ip_allowlist.py
+++ b/tests/test_ip_allowlist.py
@@ -58,6 +58,6 @@ def test_invalid_ip_logs_warning(caplog):
         r = client.get("/")
         assert r.status_code == HTTPStatus.FORBIDDEN
     assert any(
-        rec.levelno == logging.WARNING and "Invalid IP address" in rec.getMessage()
+        rec.levelno == logging.WARNING and "Unparseable IP address" in rec.getMessage()
         for rec in caplog.records
     )


### PR DESCRIPTION
## Summary
- warn when IP address can't be parsed
- test invalid IP logging and 403 response

## Testing
- `pytest tests/test_ip_allowlist.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55b1eea308329be32d8d59a4ed4ca