### PR TITLE
Refactor callback URL validation and testing

### DIFF
--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -23,13 +23,22 @@ class Settings(BaseSettings):
     skip_auth_paths: list[str] = Field(
         default_factory=lambda: ["/v1/healthz", "/metrics"], env="SKIP_AUTH_PATHS"
     )
+    callback_url_allowed_hosts: str = Field(
+        default="", env="CALLBACK_URL_ALLOWED_HOSTS"
+    )
     rate_limit_redis_url: str = Field(env="RATE_LIMIT_REDIS_URL")
     rate_limit_per_key: int = Field(default=120, env="RATE_LIMIT_PER_KEY")
     rate_limit_per_ip: int = Field(default=120, env="RATE_LIMIT_PER_IP")
     rate_limit_per_org: int = Field(default=120, env="RATE_LIMIT_PER_ORG")
     health_tcp_checks: list[str] = Field(default_factory=list, env="HEALTH_TCP_CHECKS")
 
-    @field_validator("cors_allow_origins", "skip_auth_paths", "health_tcp_checks", "ip_allowlist", mode="before")
+    @field_validator(
+        "cors_allow_origins",
+        "skip_auth_paths",
+        "health_tcp_checks",
+        "ip_allowlist",
+        mode="before",
+    )
     @classmethod
     def _split_csv(cls, value: str | list[str]) -> list[str]:
         if isinstance(value, str):

--- a/tests/test_callback_validation.py
+++ b/tests/test_callback_validation.py
@@ -20,7 +20,7 @@ def test_invalid_callback_scheme() -> None:
             json={"text": "x", "callback_url": "ftp://example.com/cb"},
         )
         assert r.status_code == HTTPStatus.BAD_REQUEST
-        assert r.json()["detail"] == "Invalid callback URL scheme"
+        assert r.json()["detail"] == "Disallowed callback URL scheme"
 
 
 def test_invalid_callback_host() -> None:
@@ -32,7 +32,7 @@ def test_invalid_callback_host() -> None:
             json={"text": "x", "callback_url": "https://evil.com/cb"},
         )
         assert r.status_code == HTTPStatus.BAD_REQUEST
-        assert r.json()["detail"] == "Invalid callback URL host"
+        assert r.json()["detail"] == "Disallowed callback URL host"
 
 
 def test_valid_callback_url() -> None:


### PR DESCRIPTION
## Summary
- add dynamic loader for allowed callback hosts
- provide specific errors for missing host, disallowed scheme, and disallowed host
- test callback URL validation and reload of host settings

## Testing
- `pytest tests/test_validate_callback_url.py tests/test_callback_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68c55b1feb508329ad35c6e5b0f0ca69