### PR TITLE
Log warning when client IP is invalid

### DIFF
--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -65,6 +65,7 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
             addr = ipaddress.ip_address(ip)
         except ValueError:
             logger.warning("Unparseable IP address %s", ip)
+            logger.warning("invalid client IP %s", ip)
             addr = None
         if addr and any(addr in n for n in self.networks):
             return await call_next(request)

--- a/tests/test_ip_allowlist.py
+++ b/tests/test_ip_allowlist.py
@@ -58,6 +58,6 @@ def test_invalid_ip_logs_warning(caplog):
         r = client.get("/")
         assert r.status_code == HTTPStatus.FORBIDDEN
     assert any(
-        rec.levelno == logging.WARNING and "Unparseable IP address" in rec.getMessage()
+        rec.levelno == logging.WARNING and "invalid client IP" in rec.getMessage()
         for rec in caplog.records
     )


### PR DESCRIPTION
## Summary
- log an extra warning when a client's IP address is invalid
- test that invalid IPs trigger warning and 403

## Testing
- `SKIP=pytest python -m pre_commit run --files src/factsynth_ultimate/core/ip_allowlist.py tests/test_ip_allowlist.py`
- `pytest tests/test_ip_allowlist.py::test_invalid_ip_logs_warning -vv`

------
https://chatgpt.com/codex/tasks/task_e_68c55edc1ec08329999951825914bc2c