### PR TITLE
Refactor GLRTPM step handlers to callable classes

### DIFF
--- a/src/factsynth_ultimate/glrtpm/pipeline.py
+++ b/src/factsynth_ultimate/glrtpm/pipeline.py
@@ -20,40 +20,46 @@ class GLRTPMStep(str, Enum):
     Omega = "Omega"
 
 
-def handle_r(thesis: str, _: dict[str, str]) -> str:
-    """Return critic response for thesis."""
+class CriticHandler:
+    """Callable returning the critic response."""
 
-    return Critic().respond(thesis)
-
-
-def handle_i(thesis: str, _: dict[str, str]) -> str:
-    """Return combined rationalist and aesthete perspectives."""
-
-    return " | ".join([Rationalist().respond(thesis), Aesthete().respond(thesis)])
+    def __call__(self, thesis: str, _: dict[str, str]) -> str:
+        return Critic().respond(thesis)
 
 
-def handle_p(thesis: str, results: dict[str, str]) -> str:
-    """Project thesis and counter arguments into a meta representation."""
+class RationalistAestheteHandler:
+    """Callable combining rationalist and aesthete perspectives."""
 
-    return "[Meta-Projection] Nodes: " + json.dumps(
-        {
-            "thesis": f"{thesis[:64]}...",
-            "counter": f"{results.get('R', '')[:64]}...",
-        }
-    )
+    def __call__(self, thesis: str, _: dict[str, str]) -> str:
+        return " | ".join(
+            [Rationalist().respond(thesis), Aesthete().respond(thesis)]
+        )
 
 
-def handle_omega(thesis: str, _: dict[str, str]) -> str:
-    """Return integrator synthesis and observer audit."""
+class ProjectionHandler:
+    """Callable projecting thesis and counter arguments into meta representation."""
 
-    return Integrator().respond(thesis) + " | " + Observer().respond(thesis)
+    def __call__(self, thesis: str, results: dict[str, str]) -> str:
+        return "[Meta-Projection] Nodes: " + json.dumps(
+            {
+                "thesis": f"{thesis[:64]}...",
+                "counter": f"{results.get('R', '')[:64]}...",
+            }
+        )
+
+
+class IntegratorObserverHandler:
+    """Callable returning integrator synthesis and observer audit."""
+
+    def __call__(self, thesis: str, _: dict[str, str]) -> str:
+        return Integrator().respond(thesis) + " | " + Observer().respond(thesis)
 
 
 STEP_HANDLERS: dict[GLRTPMStep, Callable[[str, dict[str, str]], str]] = {
-    GLRTPMStep.R: handle_r,
-    GLRTPMStep.I: handle_i,
-    GLRTPMStep.P: handle_p,
-    GLRTPMStep.Omega: handle_omega,
+    GLRTPMStep.R: CriticHandler(),
+    GLRTPMStep.I: RationalistAestheteHandler(),
+    GLRTPMStep.P: ProjectionHandler(),
+    GLRTPMStep.Omega: IntegratorObserverHandler(),
 }
 
 

--- a/tests/test_glrtpm.py
+++ b/tests/test_glrtpm.py
@@ -1,6 +1,6 @@
 import pytest
 
-from factsynth_ultimate.glrtpm.pipeline import GLRTPMConfig, GLRTPMPipeline
+from factsynth_ultimate.glrtpm.pipeline import GLRTPMConfig, GLRTPMPipeline, GLRTPMStep
 
 pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
@@ -15,3 +15,10 @@ def test_glrtpm_roundtrip():
 def test_unknown_step_raises_error():
     with pytest.raises(ValueError, match="Unknown GLRTPM step: X"):
         GLRTPMPipeline(GLRTPMConfig(steps=["X"]))
+
+
+def test_unknown_step_in_mixed_sequence_raises_error():
+    """Ensure error is raised when sequence contains an unknown step."""
+
+    with pytest.raises(ValueError, match="Unknown GLRTPM step: Z"):
+        GLRTPMPipeline(GLRTPMConfig(steps=[GLRTPMStep.R, "Z"]))


### PR DESCRIPTION
## Summary
- Replace lambda role steps with dedicated callable handler classes
- Ensure pipeline config steps validate against `GLRTPMStep`
- Add tests checking unknown step names error out

## Testing
- `ruff check src/factsynth_ultimate/glrtpm/pipeline.py tests/test_glrtpm.py`
- `pytest tests/test_glrtpm.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55edcfa6083298af40f516824defd