### PR TITLE
chore: log invalid IP and test warning

### DIFF
--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -64,8 +64,8 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         try:
             addr = ipaddress.ip_address(ip)
         except ValueError:
-            logger.warning("Unparseable IP address %s", ip)
             logger.warning("invalid client IP %s", ip)
+            logger.warning("Unparseable IP address %s", ip)
             addr = None
         if addr and any(addr in n for n in self.networks):
             return await call_next(request)

--- a/tests/test_ip_allowlist.py
+++ b/tests/test_ip_allowlist.py
@@ -61,3 +61,7 @@ def test_invalid_ip_logs_warning(caplog):
         rec.levelno == logging.WARNING and "invalid client IP" in rec.getMessage()
         for rec in caplog.records
     )
+    assert any(
+        rec.levelno == logging.WARNING and "Unparseable IP address" in rec.getMessage()
+        for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log invalid client IP before noting it is unparseable
- test invalid IP warning and forbidden response

## Testing
- `pytest tests/test_ip_allowlist.py::test_invalid_ip_logs_warning -q`


------
https://chatgpt.com/codex/tasks/task_e_68c563fbead883298aa8b9f26b94588a