### PR TITLE
Add GLRTPM step enum and handler validation

### DIFF
--- a/src/factsynth_ultimate/glrtpm/pipeline.py
+++ b/src/factsynth_ultimate/glrtpm/pipeline.py
@@ -102,8 +102,9 @@ class GLRTPMPipeline:
         results: dict[str, str] = {}
         for step in self.config.steps:
             handler = STEP_HANDLERS.get(step)
-            if handler:
-                results[step.value] = handler(thesis, results)
+            if handler is None:
+                raise ValueError(f"Unsupported GLRTPM step: {step.value}")
+            results[step.value] = handler(thesis, results)
 
         metrics = {
             "coherence": compute_coherence(thesis, *results.values()),

--- a/tests/test_glrtpm_pipeline_handlers.py
+++ b/tests/test_glrtpm_pipeline_handlers.py
@@ -1,0 +1,39 @@
+import pytest
+
+from factsynth_ultimate.glrtpm.pipeline import (
+    GLRTPMConfig,
+    GLRTPMPipeline,
+    GLRTPMStep,
+    STEP_HANDLERS,
+    CriticHandler,
+    IntegratorObserverHandler,
+    ProjectionHandler,
+    RationalistAestheteHandler,
+)
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
+def test_step_handlers_mapping_matches_enum():
+    """Each enum member should map to its dedicated handler class."""
+
+    expected = {
+        GLRTPMStep.R: CriticHandler,
+        GLRTPMStep.I: RationalistAestheteHandler,
+        GLRTPMStep.P: ProjectionHandler,
+        GLRTPMStep.Omega: IntegratorObserverHandler,
+    }
+
+    assert set(STEP_HANDLERS) == set(expected)
+    for step, cls in expected.items():
+        assert isinstance(STEP_HANDLERS[step], cls)
+
+
+def test_run_raises_for_unsupported_step(monkeypatch):
+    """Pipeline should raise a clear error when handler is missing."""
+
+    pipeline = GLRTPMPipeline(GLRTPMConfig(steps=[GLRTPMStep.R]))
+    monkeypatch.delitem(STEP_HANDLERS, GLRTPMStep.R, raising=False)
+
+    with pytest.raises(ValueError, match="Unsupported GLRTPM step: R"):
+        pipeline.run("thesis")


### PR DESCRIPTION
## Summary
- expand GLRTPM pipeline with explicit step enum
- validate pipeline steps and raise on unsupported ones
- cover handlers and error paths with unit tests

## Testing
- `pytest tests/test_glrtpm.py tests/test_glrtpm_pipeline_handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_68c563fcb72083299ef7622655d3cf7b