### PR TITLE
docs: clarify dev dependency source

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ Set up a local development environment:
 
 ### Development dependencies
 
-`requests` powers the contract tests while `PyYAML` supports schema
-validation. These and all other development dependencies live in
-`pyproject.toml` under the `dev` extra and are **pinned** in
-`requirements-dev.txt`. Regenerate the lockfile with
+The `[project.optional-dependencies].dev` section of `pyproject.toml`
+is the **single source of truth** for tooling needed to work on
+FactSynth. The `requirements-dev.txt` lockfile is generated from that
+list and should not be edited by hand. Regenerate it with
 `scripts/update_dev_requirements.sh` (a thin wrapper around
 `pip-compile`) and install with `pip install -r requirements-dev.txt`.
 Pre-commit and the CI workflow both run `pip-compile` and fail if the


### PR DESCRIPTION
## Summary
- document pyproject's `dev` extra as the single source of truth for development tooling

## Testing
- `pre-commit run --files README.md pyproject.toml requirements-dev.txt`
- `pytest -q` *(fails: mocked responses not requested)*

------
https://chatgpt.com/codex/tasks/task_e_68c563fd77048329ae9b24427ad889df