### PR TITLE
feat: centralize configuration settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Example environment variables for container build
 ENV=dev
 API_KEY=change-me
+AUTH_HEADER_NAME=x-api-key
+IP_ALLOWLIST=
+CORS_ORIGINS=
 RATE_LIMIT_REDIS_URL=redis://localhost:6379/0
 RATE_LIMIT_PER_KEY=120
 RATE_LIMIT_PER_IP=120

--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ A Redis instance is required for rate limiting; set `RATE_LIMIT_REDIS_URL` to th
 | -------- | ------- | ----------- |
 | `ENV` | `dev` | Environment name. |
 | `HTTPS_REDIRECT` | `false` | Redirect HTTP to HTTPS. |
-| `CORS_ALLOW_ORIGINS` | *(empty)* | Comma-separated origins. Defaults to denying all; set explicitly to allow specific domains. |
+| `CORS_ORIGINS` | *(empty)* | Comma-separated origins. Defaults to denying all; set explicitly to allow specific domains. |
+| `API_KEY` | *(none)* | Secret key required for authentication. |
 | `AUTH_HEADER_NAME` | `x-api-key` | Header carrying API key. |
 | `IP_ALLOWLIST` | *(empty)* | Allowed IPs, comma-separated. |
 | `RATE_LIMIT_REDIS_URL` | *(none)* | Redis connection URL for rate limiting. |
@@ -187,15 +188,15 @@ A Redis instance is required for rate limiting; set `RATE_LIMIT_REDIS_URL` to th
 ### Allowed origins
 
 By default, no cross-origin requests are permitted. To enable cross-origin
-access, set `CORS_ALLOW_ORIGINS` to a comma-separated list of allowed origins,
+access, set `CORS_ORIGINS` to a comma-separated list of allowed origins,
 for example:
 
 ```bash
-export CORS_ALLOW_ORIGINS="https://example.com,https://another.example"
+export CORS_ORIGINS="https://example.com,https://another.example"
 ```
 
 To permit any origin (not recommended for production), use
-`CORS_ALLOW_ORIGINS="*"`.
+`CORS_ORIGINS="*"`.
 
 Secrets are supplied via GitHub Secrets or environment variables.
 

--- a/src/factsynth_ultimate/core/config.py
+++ b/src/factsynth_ultimate/core/config.py
@@ -1,0 +1,63 @@
+"""Centralized application configuration."""
+
+from __future__ import annotations
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .secrets import read_api_key
+
+
+class Config(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    model_config = SettingsConfigDict(env_prefix="")
+
+    auth_header_name: str = Field(default="x-api-key", env="AUTH_HEADER_NAME")
+    api_key: str = Field(
+        default_factory=lambda: read_api_key("API_KEY", "API_KEY_FILE", "change-me", "API_KEY")
+    )
+    ip_allowlist: list[str] = Field(default_factory=list, env="IP_ALLOWLIST")
+    cors_origins: list[str] = Field(default_factory=list, env="CORS_ORIGINS")
+    rate_limit_redis_url: str = Field(
+        default="redis://localhost:6379/0", env="RATE_LIMIT_REDIS_URL"
+    )
+    rate_limit_per_key: int = Field(default=120, env="RATE_LIMIT_PER_KEY")
+    rate_limit_per_ip: int = Field(default=120, env="RATE_LIMIT_PER_IP")
+    rate_limit_per_org: int = Field(default=120, env="RATE_LIMIT_PER_ORG")
+
+    @field_validator("ip_allowlist", "cors_origins", mode="before")
+    @classmethod
+    def _split_csv(cls, value: str | list[str]) -> list[str]:
+        if isinstance(value, str):
+            if not value:
+                return []
+            return [item for item in value.split(",") if item]
+        return list(value)
+
+    @field_validator("auth_header_name")
+    @classmethod
+    def _non_empty_header(cls, value: str) -> str:
+        if not value:
+            raise ValueError("AUTH_HEADER_NAME must not be empty")
+        return value
+
+    @field_validator("api_key")
+    @classmethod
+    def _validate_api_key(cls, value: str) -> str:
+        if not value:
+            raise ValueError("API_KEY must not be empty")
+        return value
+
+    @field_validator("rate_limit_per_key", "rate_limit_per_ip", "rate_limit_per_org")
+    @classmethod
+    def _non_negative(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("Rate limits must be non-negative")
+        return value
+
+
+def load_config() -> Config:
+    """Load configuration from environment variables."""
+
+    return Config()


### PR DESCRIPTION
## Summary
- add Config BaseSettings for common env vars
- use Config in rate limit middleware and routers
- document AUTH_HEADER_NAME, API_KEY, IP_ALLOWLIST, CORS_ORIGINS, rate limit vars

## Testing
- `pre-commit run --files src/factsynth_ultimate/core/config.py src/factsynth_ultimate/core/ratelimit.py src/factsynth_ultimate/api/routers.py src/factsynth_ultimate/app.py .env.example README.md` *(fails: AssertionError: mocked responses not requested, validation errors, rate limit tests failing)*
- `pytest -q` *(fails: mocked responses not requested, validation errors, rate limit tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c566217424832989eacf948b384ecc