### PR TITLE
feat: add case-insensitive API key middleware

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,52 @@
+import os
+import string
+from http import HTTPStatus
+
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+API_KEY = os.getenv("API_KEY", "change-me")
+
+
+@st.composite
+def header_variations(draw):
+    name_flags = draw(st.lists(st.booleans(), min_size=len("x-api-key"), max_size=len("x-api-key")))
+    name = "".join(
+        c.upper() if flag else c.lower() for c, flag in zip("x-api-key", name_flags, strict=False)
+    )
+    value_flags = draw(st.lists(st.booleans(), min_size=len(API_KEY), max_size=len(API_KEY)))
+    value = "".join(
+        c.upper() if flag else c.lower() for c, flag in zip(API_KEY, value_flags, strict=False)
+    )
+    return name, value
+
+
+@pytest.mark.anyio
+@given(header_variations())
+async def test_api_key_case_insensitive(client, header_variations):
+    name, value = header_variations
+    r = await client.post(
+        "/v1/generate", headers={name: value}, json={"text": "hello"}
+    )
+    assert r.status_code == HTTPStatus.OK
+
+
+@st.composite
+def invalid_keys(draw):
+    alphabet = string.ascii_letters + string.digits
+    key = draw(
+        st.text(alphabet=alphabet, min_size=len(API_KEY), max_size=len(API_KEY))
+    )
+    assume(key.casefold() != API_KEY.casefold())
+    return key
+
+
+@pytest.mark.anyio
+@given(invalid_keys())
+async def test_invalid_key_rejected(client, invalid_keys):
+    key = invalid_keys
+    r = await client.post(
+        "/v1/generate", headers={"x-api-key": key}, json={"text": "hi"}
+    )
+    assert r.status_code == HTTPStatus.FORBIDDEN

--- a/tests/test_score_and_auth.py
+++ b/tests/test_score_and_auth.py
@@ -21,7 +21,7 @@ def test_auth_required() -> None:
             "type": "about:blank",
             "title": "Unauthorized",
             "status": HTTPStatus.UNAUTHORIZED,
-            "detail": "Invalid or missing API key",
+            "detail": "Missing API key",
         }
         assert (
             client.post(url, headers={"x-api-key": "secret"}, json={"text": "x"}).status_code


### PR DESCRIPTION
## Summary
- normalize header API keys to handle case-insensitive comparisons
- log client and request identifiers on auth failure and emit RFC 9457 responses
- fuzz-test API key headers and update auth tests for 401/403 handling

## Testing
- `ruff check tests/test_auth.py tests/test_score_and_auth.py src/factsynth_ultimate/core/auth.py`
- `pytest tests/test_auth.py tests/test_score_and_auth.py tests/test_auth_and_skiplist.py` *(fails: AttributeError: 'FakeReader' object has no attribute 'at_eof')*

------
https://chatgpt.com/codex/tasks/task_e_68c5662197708329a50b746a8839d3ac