### PR TITLE
Log request id on NLI fallback

### DIFF
--- a/src/factsynth_ultimate/services/nli.py
+++ b/src/factsynth_ultimate/services/nli.py
@@ -18,7 +18,9 @@ class NLI:
     def __init__(self, classifier: Classifier | None = None) -> None:
         self.classifier = classifier
 
-    async def classify(self, premise: str, hypothesis: str) -> float:
+    async def classify(
+        self, premise: str, hypothesis: str, request_id: str | None = None
+    ) -> float:
         """Return entailment score for *hypothesis* given *premise*.
 
         If an async *classifier* was provided, it will be awaited. Any exception
@@ -30,8 +32,10 @@ class NLI:
             try:
                 return await self.classifier(premise, hypothesis)
             except Exception:
-                logger.exception("classifier_error")
-                pass
+                logger.exception(
+                    "classifier_error", extra={"request_id": request_id}
+                )
+                return self._heuristic(premise, hypothesis)
         return self._heuristic(premise, hypothesis)
 
     def _heuristic(self, premise: str, hypothesis: str) -> float:


### PR DESCRIPTION
## Summary
- attach optional request id when logging classifier errors in NLI
- ensure token-overlap fallback runs after logging
- test that classifier errors log request id and still fall back

## Testing
- `pytest tests/test_nli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c56624fc7c8329a579f15c0e47d638