### PR TITLE
feat: define strict lock contract

### DIFF
--- a/tests/test_factsynth_lock.py
+++ b/tests/test_factsynth_lock.py
@@ -9,9 +9,7 @@ pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def test_unknown_field_rejected():
     data = {
         "verdict": {"decision": "supported"},
-        "source_synthesis": {"summary": "summary"},
-        "traceability": {},
-        "recommendations": {},
+        "evidence": [{"source": "url", "content": "text"}],
         "unexpected": "value",
     }
 
@@ -27,3 +25,10 @@ def test_invalid_decision_rejected():
 def test_verdict_rejects_unknown_field():
     with pytest.raises(ValidationError):
         Verdict.model_validate({"decision": Decision.SUPPORTED, "extra": "value"})
+
+
+def test_lock_requires_evidence():
+    data = {"verdict": {"decision": "supported"}, "evidence": []}
+
+    with pytest.raises(ValidationError):
+        FactSynthLock.model_validate(data)

--- a/tests/test_factsynth_lock_contract.py
+++ b/tests/test_factsynth_lock_contract.py
@@ -9,15 +9,13 @@ pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def minimal_lock_data() -> dict:
     return {
         "verdict": {"decision": "supported"},
-        "source_synthesis": {"summary": "summary"},
-        "traceability": {},
-        "recommendations": {},
+        "evidence": [{"source": "url", "content": "text"}],
     }
 
 
 def test_unknown_field_in_nested_model_rejected():
     data = minimal_lock_data()
-    data["source_synthesis"]["unexpected"] = "value"
+    data["evidence"][0]["unexpected"] = "value"
 
     with pytest.raises(ValidationError):
         FactSynthLock.model_validate(data)

--- a/tests/test_quality_pipeline.py
+++ b/tests/test_quality_pipeline.py
@@ -19,9 +19,7 @@ def test_quality_pipeline_verify_returns_lock():
         "claim": "The earth orbits the sun",
         "lock": {
             "verdict": {"decision": "supported"},
-            "source_synthesis": {"summary": "summary"},
-            "traceability": {},
-            "recommendations": {},
+            "evidence": [{"source": "url", "content": "text"}],
         },
     }
 


### PR DESCRIPTION
## Summary
- replace dataclasses with strict Pydantic models for FactSynth lock
- forbid unknown fields and validate evidence list
- update tests for new lock/verdict/evidence schema

## Testing
- `pytest tests/test_factsynth_lock.py tests/test_factsynth_lock_contract.py tests/test_quality_pipeline.py tests/test_evaluator_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68c56a334ab483298241ba00383f024e