### PR TITLE
Use constant-time API key check and fuzz header tests

### DIFF
--- a/src/factsynth_ultimate/core/auth.py
+++ b/src/factsynth_ultimate/core/auth.py
@@ -56,11 +56,12 @@ class APIKeyAuthMiddleware(BaseHTTPMiddleware):
         if not self.api_key:
             return await call_next(request)
 
-        expected = self.api_key.casefold()
+        expected = self.api_key.casefold().encode()
         if provided is None:
             return self._reject(request, 401, "Missing API key", "unauthorized")
 
-        if hmac.compare_digest(provided.casefold(), expected):
+        provided_bytes = provided.casefold().encode()
+        if hmac.compare_digest(provided_bytes, expected):
             return await call_next(request)
 
         return self._reject(request, 403, "Invalid API key", "forbidden")
@@ -79,6 +80,7 @@ class APIKeyAuthMiddleware(BaseHTTPMiddleware):
             "title": translate(lang, title_key),
             "status": status,
             "detail": detail,
+            "instance": request.url.path,
             "trace_id": request_id,
         }
         return JSONResponse(problem, status_code=status, media_type="application/problem+json")


### PR DESCRIPTION
## Summary
- compare API key using `hmac.compare_digest` on bytes for constant-time checks
- log `client_id` and `request_id` when auth fails and return RFC9457 problem responses with instance path
- fuzz header names in auth tests to assert 401 on missing key and 403 on invalid key

## Testing
- `ruff check src/factsynth_ultimate/core/auth.py tests/test_auth.py`
- `pytest tests/test_auth.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c56a357964832998bd21db61d96440