### PR TITLE
Apply rate limiting after auth and expose reset headers

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -5,13 +5,20 @@ from fakeredis.aioredis import FakeRedis
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from factsynth_ultimate.core.rate_limit import RateLimitMiddleware
+from factsynth_ultimate.core.ratelimit import RateLimitMiddleware
 
 
-def _build_app(burst=2, sustain=1.0):
+def _build_app(limit: int = 2, window: int = 1):
     redis = FakeRedis()
     app = FastAPI()
-    app.add_middleware(RateLimitMiddleware, redis=redis, burst=burst, sustain=sustain)
+    app.add_middleware(
+        RateLimitMiddleware,
+        redis=redis,
+        per_key=limit,
+        per_ip=0,
+        per_org=0,
+        window=window,
+    )
 
     @app.get("/route")
     async def route():
@@ -20,9 +27,14 @@ def _build_app(burst=2, sustain=1.0):
     return app, redis
 
 
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch):
+    monkeypatch.setenv("API_KEY", "k")
+
+
 @pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def test_burst_limit_exceeded():
-    app, _ = _build_app(burst=2, sustain=1)
+    app, _ = _build_app(limit=2, window=1)
     with TestClient(app) as client:
         headers = {"x-api-key": "k"}
         assert client.get("/route", headers=headers).status_code == 200
@@ -32,14 +44,30 @@ def test_burst_limit_exceeded():
         assert resp.headers["X-RateLimit-Limit"] == "2"
         assert resp.headers["X-RateLimit-Remaining"] == "0"
         assert resp.headers["Retry-After"] == "1"
+        assert "X-RateLimit-Reset" in resp.headers
 
 
 @pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
-def test_sustained_requests_allowed():
-    app, _ = _build_app(burst=2, sustain=4)
+def test_limit_resets_after_window():
+    app, _ = _build_app(limit=2, window=1)
     with TestClient(app) as client:
         headers = {"x-api-key": "k"}
-        for _ in range(5):
-            resp = client.get("/route", headers=headers)
-            assert resp.status_code == 200
-            time.sleep(0.3)
+        client.get("/route", headers=headers)
+        client.get("/route", headers=headers)
+        assert client.get("/route", headers=headers).status_code == 429
+        time.sleep(1.1)
+        resp = client.get("/route", headers=headers)
+        assert resp.status_code == 200
+        assert resp.headers["X-RateLimit-Remaining"] == "1"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_headers_on_success():
+    app, _ = _build_app(limit=2, window=1)
+    with TestClient(app) as client:
+        headers = {"x-api-key": "k"}
+        resp = client.get("/route", headers=headers)
+        assert resp.status_code == 200
+        assert resp.headers["X-RateLimit-Limit"] == "2"
+        assert resp.headers["X-RateLimit-Remaining"] == "1"
+        assert resp.headers["X-RateLimit-Reset"] == "1"


### PR DESCRIPTION
## Summary
- enforce rate limiting only after verifying the API key
- include standard X-RateLimit headers plus Retry-After with window reset
- test burst exhaustion, window reset, and presence of 429 and rate limit headers

## Testing
- `pytest tests/test_rate_limit.py`


------
https://chatgpt.com/codex/tasks/task_e_68c56a3636f883299e5353e034b2f4b1