### PR TITLE
ci: define Python 3.10-3.12 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
     env:
       API_KEY: change-me
       RATE_LIMIT_REDIS_URL: redis://test

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ structured logs, and tracing hooks.
 [![FastAPI](assets/fastapi.svg)](https://fastapi.tiangolo.com/)
 [![Uvicorn](assets/uvicorn.svg)](https://www.uvicorn.org/)
 
-Python 3.10+ · FastAPI 0.116 · Uvicorn 0.35  
+Python 3.10–3.12 · FastAPI 0.116 · Uvicorn 0.35
 See full [dependency graph](https://github.com/neuron7x/FactSynth/network/dependencies).
 
 ## Quick Start

--- a/README_UA.md
+++ b/README_UA.md
@@ -48,7 +48,7 @@ FactSynth — це мікросервіс FastAPI для екстрактивн�
 [![FastAPI](assets/fastapi.svg)](https://fastapi.tiangolo.com/)
 [![Uvicorn](assets/uvicorn.svg)](https://www.uvicorn.org/)
 
-Python 3.10+ · FastAPI 0.116 · Uvicorn 0.35
+Python 3.10–3.12 · FastAPI 0.116 · Uvicorn 0.35
 
 ## Швидкий старт
 


### PR DESCRIPTION
## Summary
- clarify CI matrix for Python 3.10–3.12
- document supported Python versions in README and README_UA

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md README_UA.md`
- `pytest -q --maxfail=1`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c56a38732c832998d5b7dd1921730e