### PR TITLE
Refine callback URL validation with dynamic host allowlist

### DIFF
--- a/tests/test_validate_callback_url.py
+++ b/tests/test_validate_callback_url.py
@@ -4,31 +4,36 @@ from fastapi import HTTPException
 from factsynth_ultimate.api import routers
 from factsynth_ultimate.api.routers import validate_callback_url
 
-
 pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 
-def test_validate_callback_url_basic(monkeypatch, httpx_mock):
+def test_validate_callback_url_disallowed_scheme(monkeypatch, httpx_mock):
     httpx_mock.reset()
-    monkeypatch.setattr(routers, "get_allowed_hosts", lambda: set())
-    validate_callback_url("https://example.com")
+    monkeypatch.setattr(routers, "get_allowed_hosts", lambda: {"example.com"})
     with pytest.raises(HTTPException) as exc:
         validate_callback_url("ftp://example.com")
     assert exc.value.detail == "Disallowed callback URL scheme"
 
 
-def test_validate_callback_url_allowed_hosts(monkeypatch, httpx_mock):
+def test_validate_callback_url_host_mismatch(monkeypatch, httpx_mock):
     httpx_mock.reset()
-    monkeypatch.setattr(routers, "get_allowed_hosts", lambda: {"a.com", "b.com"})
-    validate_callback_url("https://a.com/path")
+    monkeypatch.setattr(routers, "get_allowed_hosts", lambda: {"a.com"})
     with pytest.raises(HTTPException) as exc:
-        validate_callback_url("https://c.com")
+        validate_callback_url("https://b.com")
     assert exc.value.detail == "Disallowed callback URL host"
+
+
+def test_validate_callback_url_empty_allowlist(monkeypatch, httpx_mock):
+    httpx_mock.reset()
+    monkeypatch.setattr(routers, "get_allowed_hosts", lambda: set())
+    with pytest.raises(HTTPException) as exc:
+        validate_callback_url("https://example.com")
+    assert exc.value.detail == "Callback URL allowlist is empty"
 
 
 def test_validate_callback_url_missing_host(monkeypatch, httpx_mock):
     httpx_mock.reset()
-    monkeypatch.setattr(routers, "get_allowed_hosts", lambda: set())
+    monkeypatch.setattr(routers, "get_allowed_hosts", lambda: {"a.com"})
     with pytest.raises(HTTPException) as exc:
         validate_callback_url("https:///path")
     assert exc.value.detail == "Missing callback URL host"
@@ -45,3 +50,4 @@ def test_validate_callback_url_dynamic_allowlist(monkeypatch, httpx_mock):
         routers.validate_callback_url("https://a.com/path")
     assert exc.value.detail == "Disallowed callback URL host"
     routers.validate_callback_url("https://b.com/path")
+


### PR DESCRIPTION
## Summary
- load callback host allowlist dynamically on each validation
- raise specific HTTP errors for empty allowlist, bad scheme and host mismatch
- test callback URL validation against new error messages

## Testing
- `ruff check src/factsynth_ultimate/api/routers.py tests/test_validate_callback_url.py`
- `pytest tests/test_validate_callback_url.py tests/test_callback_validation.py`
- `pytest` *(fails: ImportError: cannot import name 'CriticHandler' from 'factsynth_ultimate.glrtpm.pipeline')*

------
https://chatgpt.com/codex/tasks/task_e_68c56d5fe6cc832984c66e6badf90337