### PR TITLE
Log warning for invalid IP address

### DIFF
--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -69,13 +69,10 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         try:
             addr = ipaddress.ip_address(ip)
         except ValueError:
-            logger.warning(
-                "request_id=%s client_ip=%s: Unparseable IP address", request_id, ip
-            )
+            logger.warning("request_id=%s client_ip=%s: Unparseable IP address", request_id, ip)
+            logger.warning("invalid client IP %s", ip)
             addr = None
         if addr and any(addr in n for n in self.networks):
             return await call_next(request)
-        logger.warning(
-            "request_id=%s client_ip=%s: IP not in allowlist", request_id, ip
-        )
+        logger.warning("request_id=%s client_ip=%s: IP not in allowlist", request_id, ip)
         return forbidden()


### PR DESCRIPTION
## Summary
- log a warning when the client IP cannot be parsed
- add test verifying invalid IP logs warning and returns 403

## Testing
- `pre-commit run --files src/factsynth_ultimate/core/ip_allowlist.py tests/test_ip_allowlist.py` *(fails: ImportError in tests/test_glrtpm_pipeline_handlers.py)*
- `pytest tests/test_ip_allowlist.py::test_invalid_ip_logs_warning_and_returns_403`

------
https://chatgpt.com/codex/tasks/task_e_68c56d60e418832988ed095c69ea6567