### PR TITLE
chore: document fakeredis and install dev extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             elif [ -f requirements.txt ]; then
               pip install -r requirements.txt
             fi
-            [ -f pyproject.toml ] && pip install -e . || true
+            [ -f pyproject.toml ] && pip install -e .[dev] || true
 
         - name: Check lockfile
           if: hashFiles('requirements.lock','pyproject.toml') != ''

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Set up a local development environment:
 The `[project.optional-dependencies].dev` section of `pyproject.toml`
 is the **single source of truth** for tooling needed to work on
 FactSynth. Install them with `pip install -e .[dev]`.
+It includes `fakeredis` so tests can run without a real Redis instance.
 A `requirements.lock` file is generated with `pip-compile` to pin
 versions; do not edit it by hand. Pre-commit and the CI workflow both
 run `pip-compile` and fail if the lockfile differs from


### PR DESCRIPTION
## Summary
- document fakeredis in development notes
- install dev extras in CI to provide fakeredis during tests

## Testing
- `pre-commit run --files README.md .github/workflows/ci.yml`
- `pytest -q` *(fails: ImportError: cannot import name 'CriticHandler')*
- `pytest tests/test_rate_limit.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c56d61e6408329a351837d37620919