### PR TITLE
Refactor GLRTPM pipeline to use enum handlers

### DIFF
--- a/tests/test_glrtpm_pipeline_handlers.py
+++ b/tests/test_glrtpm_pipeline_handlers.py
@@ -1,11 +1,11 @@
 import pytest
 
 from factsynth_ultimate.glrtpm.pipeline import (
+    STEP_HANDLERS,
+    CriticHandler,
     GLRTPMConfig,
     GLRTPMPipeline,
     GLRTPMStep,
-    STEP_HANDLERS,
-    CriticHandler,
     IntegratorObserverHandler,
     ProjectionHandler,
     RationalistAestheteHandler,
@@ -37,3 +37,10 @@ def test_run_raises_for_unsupported_step(monkeypatch):
 
     with pytest.raises(ValueError, match="Unsupported GLRTPM step: R"):
         pipeline.run("thesis")
+
+
+def test_config_rejects_unknown_step():
+    """Configuration should reject steps not defined in ``GLRTPMStep``."""
+
+    with pytest.raises(ValueError, match="Unknown GLRTPM step: X"):
+        GLRTPMConfig(["X"])


### PR DESCRIPTION
## Summary
- introduce dedicated handler classes mapped from new `GLRTPMStep` enum
- surface clearer `UnknownGLRTPMStepError` when configuration or pipeline steps are invalid
- test step-handler mapping and configuration validation

## Testing
- `SKIP=pytest pre-commit run --files src/factsynth_ultimate/glrtpm/pipeline.py tests/test_glrtpm_pipeline_handlers.py tests/test_glrtpm_pipeline.py`
- `pytest tests/test_glrtpm_pipeline.py tests/test_glrtpm_pipeline_handlers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c56d61507c8329a9dde1e7a1cf30ad