### PR TITLE
Log invalid client IP and test warning

### DIFF
--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -69,7 +69,11 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
         try:
             addr = ipaddress.ip_address(ip)
         except ValueError:
-            logger.warning("request_id=%s client_ip=%s: Unparseable IP address", request_id, ip)
+            logger.warning(
+                "request_id=%s client_ip=%s: Unparseable IP address",
+                request_id,
+                ip,
+            )
             logger.warning("invalid client IP %s", ip)
             addr = None
         if addr and any(addr in n for n in self.networks):

--- a/tests/test_ip_allowlist.py
+++ b/tests/test_ip_allowlist.py
@@ -85,6 +85,8 @@ def test_invalid_ip_logs_warning_and_returns_403(caplog):
     with TestClient(app) as client, caplog.at_level(logging.WARNING):
         r = client.get("/")
         assert r.status_code == HTTPStatus.FORBIDDEN
+        body = r.json()
+        assert body["detail"] == "IP testclient not allowed"
     assert any(
         rec.levelno == logging.WARNING and "invalid client IP testclient" in rec.getMessage()
         for rec in caplog.records


### PR DESCRIPTION
## Summary
- log invalid client IPs when address parsing fails
- assert response body in invalid IP warning test

## Testing
- `python -m ruff check src/factsynth_ultimate/core/ip_allowlist.py tests/test_ip_allowlist.py`
- `python -m mypy src/factsynth_ultimate/core/ip_allowlist.py`
- `pytest tests/test_ip_allowlist.py::test_invalid_ip_logs_warning_and_returns_403 -q`

------
https://chatgpt.com/codex/tasks/task_e_68c56fd4f75483299c4891c0a2e7a964