### PR TITLE
feat: ensure dev requirements stay in sync with pyproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,17 @@ jobs:
             fi
             [ -f pyproject.toml ] && pip install -e .[dev] || true
 
-        - name: Check lockfile
-          if: hashFiles('requirements.lock','pyproject.toml') != ''
-          run: |
-            pip-compile pyproject.toml --allow-unsafe --extra=dev --extra=isr --extra=numpy --generate-hashes --output-file=requirements.lock
-            git diff --exit-code requirements.lock
+      - name: Check lockfile
+        if: hashFiles('requirements.lock','pyproject.toml') != ''
+        run: |
+          pip-compile pyproject.toml --allow-unsafe --extra=dev --extra=isr --extra=numpy --generate-hashes --output-file=requirements.lock
+          git diff --exit-code requirements.lock
+
+      - name: Check dev requirements
+        if: hashFiles('pyproject.toml','requirements-dev.txt') != ''
+        run: |
+          scripts/update_dev_requirements.sh
+          git diff --exit-code requirements-dev.txt
 
       - name: Lint JS
         if: hashFiles('package.json') != ''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
         language: system
         pass_filenames: false
         types: [python]
+      - id: update-dev-requirements
+        name: update dev requirements
+        entry: scripts/update_dev_requirements.sh
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|requirements-dev\.txt)$
   - repo: https://github.com/jazzband/pip-tools
     rev: v7.5.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -100,10 +100,17 @@ Set up a local development environment:
 
 ### Development dependencies
 
-The `[project.optional-dependencies].dev` section of `pyproject.toml`
-is the **single source of truth** for tooling needed to work on
+The `[project.optional-dependencies].dev` section of `pyproject.toml` is
+the **single source of truth** for tooling needed to work on
 FactSynth. Install them with `pip install -e .[dev]`.
 It includes `fakeredis` so tests can run without a real Redis instance.
+
+For environments that expect a requirements file, run
+`scripts/update_dev_requirements.sh` to generate
+`requirements-dev.txt` from the `dev` extra. Pre-commit and the CI
+workflow execute this script and fail if `requirements-dev.txt` does not
+match `pyproject.toml`.
+
 A `requirements.lock` file is generated with `pip-compile` to pin
 versions; do not edit it by hand. Pre-commit and the CI workflow both
 run `pip-compile` and fail if the lockfile differs from

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,16 @@
+pytest==8.4.2
+schemathesis==4.1.4
+websockets==15.0.1
+pytest-cov==7.0.0
+requests==2.32.5
+pip-audit==2.9.0
+spectral==0.24
+fakeredis==2.23.1
+hypothesis==6.138.15
+numpy==1.26.4
+jax==0.4.38
+jaxlib==0.4.38
+diffrax==0.7.0
+pre-commit==4.3.0
+pytest-httpx==0.35.0
+pip-tools==7.5.0

--- a/scripts/update_dev_requirements.sh
+++ b/scripts/update_dev_requirements.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python - <<'PY'
+import pathlib
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python <3.11
+    import tomli as tomllib
+
+data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
+dev_deps = data.get('project', {}).get('optional-dependencies', {}).get('dev', [])
+pathlib.Path('requirements-dev.txt').write_text("\n".join(dev_deps) + ("\n" if dev_deps else ""))
+PY


### PR DESCRIPTION
## Summary
- generate `requirements-dev.txt` from the `dev` extra in `pyproject.toml`
- document dev dependency workflow
- enforce sync via pre-commit hook and CI step

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml scripts/update_dev_requirements.sh .github/workflows/ci.yml requirements-dev.txt`
- `pytest -q` *(fails: The following responses are mocked but not requested)*

------
https://chatgpt.com/codex/tasks/task_e_68c56fd540148329bd0839faafdae891