### PR TITLE
Add domain metadata schema and source URL validation

### DIFF
--- a/docs/domain-schema.md
+++ b/docs/domain-schema.md
@@ -1,0 +1,34 @@
+# Domain Schema
+
+This document defines domain-level attributes required for claim ingestion.
+
+## Attributes
+
+### `region`
+- **Type:** string (ISO 3166-1 alpha-2)
+- **Required:** yes
+- **Validation:** must be two uppercase letters (e.g. `US`).
+
+### `language`
+- **Type:** string (ISO 639-1)
+- **Required:** yes
+- **Validation:** must be two lowercase letters (e.g. `en`).
+
+### `time_range`
+- **Type:** object with `start` and `end` fields
+- **Required:** yes
+- **Validation:**
+  - `start` and `end` are ISO 8601 timestamps.
+  - `end` must not precede `start`.
+
+### Evidence `source`
+- **Type:** string (URL)
+- **Required:** yes
+- **Validation:** must be a valid HTTP or HTTPS URL.
+
+## Schemas
+
+JSON Schema: [`prompts/SCHEMAS/domain.schema.json`](../prompts/SCHEMAS/domain.schema.json)
+
+Avro Schema: [`prompts/SCHEMAS/domain.avsc`](../prompts/SCHEMAS/domain.avsc)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,3 +18,4 @@ nav:
   - Prompt Pack: PromptPack.md
   - Incubation Co-Dev UA: INCUBATION_CO_DEV_UA.md
   - FactSynth Lock: FACTSYNTH_LOCK.md
+  - Domain Schema: domain-schema.md

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -120,6 +120,11 @@ paths:
               sample:
                 value:
                   claim: "The earth orbits the sun"
+                  region: "US"
+                  language: "en"
+                  time_range:
+                    start: "2020-01-01T00:00:00Z"
+                    end: "2020-12-31T23:59:59Z"
                   lock:
                     version: "1.1"
                     nonce: "abc123"
@@ -273,9 +278,32 @@ components:
       type: object
       required:
         - claim
+        - region
+        - language
+        - time_range
         - lock
       properties:
         claim:
           type: string
+        region:
+          type: string
+          pattern: '^[A-Z]{2}$'
+          description: ISO 3166-1 alpha-2 region code
+        language:
+          type: string
+          pattern: '^[a-z]{2}$'
+          description: ISO 639-1 language code
+        time_range:
+          type: object
+          required:
+            - start
+            - end
+          properties:
+            start:
+              type: string
+              format: date-time
+            end:
+              type: string
+              format: date-time
         lock:
           $ref: '#/components/schemas/FactSynthLock_v1_1'

--- a/openapi/paths/verify.yaml
+++ b/openapi/paths/verify.yaml
@@ -12,6 +12,11 @@ post:
           sample:
             value:
               claim: "The earth orbits the sun"
+              region: "US"
+              language: "en"
+              time_range:
+                start: "2020-01-01T00:00:00Z"
+                end: "2020-12-31T23:59:59Z"
               lock:
                 version: "1.1"
                 nonce: "abc123"

--- a/prompts/SCHEMAS/domain.avsc
+++ b/prompts/SCHEMAS/domain.avsc
@@ -1,0 +1,34 @@
+{
+  "type": "record",
+  "name": "ClaimDomain",
+  "namespace": "factsynth",
+  "fields": [
+    {
+      "name": "region",
+      "type": "string",
+      "doc": "ISO 3166-1 alpha-2 region code"
+    },
+    {
+      "name": "language",
+      "type": "string",
+      "doc": "ISO 639-1 language code"
+    },
+    {
+      "name": "time_range",
+      "type": {
+        "type": "record",
+        "name": "TimeRange",
+        "fields": [
+          {
+            "name": "start",
+            "type": {"type": "long", "logicalType": "timestamp-millis"}
+          },
+          {
+            "name": "end",
+            "type": {"type": "long", "logicalType": "timestamp-millis"}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/prompts/SCHEMAS/domain.schema.json
+++ b/prompts/SCHEMAS/domain.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Claim domain metadata",
+  "type": "object",
+  "properties": {
+    "region": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}$",
+      "description": "ISO 3166-1 alpha-2 region code"
+    },
+    "language": {
+      "type": "string",
+      "pattern": "^[a-z]{2}$",
+      "description": "ISO 639-1 language code"
+    },
+    "time_range": {
+      "type": "object",
+      "properties": {
+        "start": {"type": "string", "format": "date-time"},
+        "end": {"type": "string", "format": "date-time"}
+      },
+      "required": ["start", "end"]
+    }
+  },
+  "required": ["region", "language", "time_range"]
+}

--- a/src/factsynth_ultimate/api/models.py
+++ b/src/factsynth_ultimate/api/models.py
@@ -2,17 +2,48 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BaseModel, Field, field_validator
 
 from ..core.factsynth_lock import FactSynthLock
+
+
+RegionCode = Annotated[
+    str,
+    Field(pattern=r"^[A-Z]{2}$", description="ISO 3166-1 alpha-2 region code"),
+]
+LanguageCode = Annotated[
+    str,
+    Field(pattern=r"^[a-z]{2}$", description="ISO 639-1 language code"),
+]
+
+
+class TimeRange(BaseModel):
+    """Time window for which the claim should hold."""
+
+    start: datetime = Field(..., description="ISO 8601 start timestamp")
+    end: datetime = Field(..., description="ISO 8601 end timestamp")
+
+    @field_validator("end")
+    @classmethod
+    def _end_after_start(cls, v: datetime, info) -> datetime:
+        start = info.data.get("start")
+        if start and v < start:
+            raise ValueError("end must not be before start")
+        return v
 
 
 class VerifyRequest(BaseModel):
     """Request model for the verification endpoint."""
 
     claim: str
+    region: RegionCode
+    language: LanguageCode
+    time_range: TimeRange
     lock: FactSynthLock
 
 
 # Export the request and lock models for use in routers
-__all__ = ["FactSynthLock", "VerifyRequest"]
+__all__ = ["FactSynthLock", "VerifyRequest", "TimeRange"]

--- a/src/factsynth_ultimate/api/verify.py
+++ b/src/factsynth_ultimate/api/verify.py
@@ -14,5 +14,10 @@ api = APIRouter()
 def verify(req: VerifyRequest) -> FactSynthLock:
     """Verify a claim and return the provided lock."""
 
-    evaluate_claim(req.claim)
+    evaluate_claim(
+        req.claim,
+        region=req.region,
+        language=req.language,
+        time_range=(req.time_range.start, req.time_range.end),
+    )
     return req.lock

--- a/src/factsynth_ultimate/core/factsynth_lock.py
+++ b/src/factsynth_ultimate/core/factsynth_lock.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 
 class _StrictModel(BaseModel):
@@ -42,8 +42,12 @@ class Verdict(_StrictModel):
 class Evidence(_StrictModel):
     """A single piece of evidence supporting the verdict."""
 
-    source: str = Field(..., min_length=1, description="Identifier or URL of the source")
-    content: str = Field(..., min_length=1, description="Excerpt taken from the source")
+    source: HttpUrl = Field(
+        ..., description="HTTP or HTTPS URL of the source"
+    )
+    content: str = Field(
+        ..., min_length=1, description="Excerpt taken from the source"
+    )
 
 
 class FactSynthLock(_StrictModel):

--- a/src/factsynth_ultimate/services/evaluator.py
+++ b/src/factsynth_ultimate/services/evaluator.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
-from typing import Any, Callable, Dict, Iterable, Optional
+from datetime import datetime
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 ResultDict = Dict[str, Any]
 
@@ -11,6 +12,9 @@ ResultDict = Dict[str, Any]
 def evaluate_claim(  # noqa: PLR0913
     claim: str,
     *,
+    region: str | None = None,
+    language: str | None = None,
+    time_range: Tuple[datetime, datetime] | None = None,
     policy_check: Callable[[str], Any] | None = None,
     scoring: Callable[[str], Any] | None = None,
     diversity: Callable[[str], Any] | None = None,
@@ -23,6 +27,9 @@ def evaluate_claim(  # noqa: PLR0913
     ----------
     claim:
         The textual claim to analyse.
+    region, language, time_range:
+        Optional domain context. Currently unused but accepted for forward
+        compatibility with enriched evaluators.
     policy_check, scoring, diversity, nli:
         Optional callables implementing each stage. They are invoked with the
         claim and their results are merged into the output dictionary under

--- a/tests/test_factsynth_lock.py
+++ b/tests/test_factsynth_lock.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def test_unknown_field_rejected():
     data = {
         "verdict": {"decision": "supported"},
-        "evidence": [{"source": "url", "content": "text"}],
+        "evidence": [{"source": "https://example.com", "content": "text"}],
         "unexpected": "value",
     }
 

--- a/tests/test_factsynth_lock_contract.py
+++ b/tests/test_factsynth_lock_contract.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def minimal_lock_data() -> dict:
     return {
         "verdict": {"decision": "supported"},
-        "evidence": [{"source": "url", "content": "text"}],
+        "evidence": [{"source": "https://example.com", "content": "text"}],
     }
 
 

--- a/tests/test_quality_pipeline.py
+++ b/tests/test_quality_pipeline.py
@@ -17,9 +17,15 @@ client = TestClient(app)
 def test_quality_pipeline_verify_returns_lock():
     payload = {
         "claim": "The earth orbits the sun",
+        "region": "US",
+        "language": "en",
+        "time_range": {
+            "start": "2020-01-01T00:00:00Z",
+            "end": "2020-12-31T23:59:59Z"
+        },
         "lock": {
             "verdict": {"decision": "supported"},
-            "evidence": [{"source": "url", "content": "text"}],
+            "evidence": [{"source": "https://example.com", "content": "text"}],
         },
     }
 


### PR DESCRIPTION
## Summary
- define `region`, `language`, and `time_range` metadata with validation
- enforce HTTP/HTTPS for evidence sources
- document domain schema and expose JSON/Avro specs

## Testing
- `pytest --cov --cov-report=xml` *(fails: mocked responses not requested; missing API key)*
- `pytest tests/test_factsynth_lock.py tests/test_factsynth_lock_contract.py tests/test_quality_pipeline.py tests/test_evaluator_api.py`
- `python tools/coverage_gate.py --xml coverage.xml --min 90` *(fails: coverage 86.34% < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68c571f7b6c483298d4d04a0bf7f5813