### PR TITLE
feat: trace source metadata through pipeline

### DIFF
--- a/src/factsynth_ultimate/core/factsynth_lock.py
+++ b/src/factsynth_ultimate/core/factsynth_lock.py
@@ -1,7 +1,7 @@
 """Pydantic models describing a FactSynth lock document.
 
 A lock bundles the final verdict of a claim evaluation together with the
-evidence used to reach it.  The models defined here are strict – unknown
+evidence used to reach it.  The models defined here are strict - unknown
 fields are rejected to ensure the contract stays stable.
 """
 
@@ -42,6 +42,9 @@ class Verdict(_StrictModel):
 class Evidence(_StrictModel):
     """A single piece of evidence supporting the verdict."""
 
+    source_id: str = Field(
+        ..., min_length=1, description="Unique identifier of the ingested source"
+    )
     source: str = Field(..., min_length=1, description="Identifier or URL of the source")
     content: str = Field(..., min_length=1, description="Excerpt taken from the source")
 

--- a/src/factsynth_ultimate/core/source_store.py
+++ b/src/factsynth_ultimate/core/source_store.py
@@ -1,0 +1,56 @@
+"""In-memory source metadata store and ingestion helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+from uuid import uuid4
+
+
+@dataclass
+class SourceMetadata:
+    """Metadata associated with an ingested source."""
+
+    url: str
+    date: str
+    hash: str
+
+
+# Simple in-memory store for source metadata
+_SOURCE_DB: dict[str, SourceMetadata] = {}
+
+
+def ingest_source(url: str, content: str) -> str:
+    """Generate a unique ``source_id`` and persist metadata.
+
+    Parameters
+    ----------
+    url:
+        Original location of the content.
+    content:
+        Raw content used to generate a stable hash.
+
+    Returns
+    -------
+    str
+        The generated ``source_id``.
+    """
+
+    source_id = uuid4().hex
+    metadata = SourceMetadata(
+        url=url,
+        date=datetime.now(UTC).isoformat(),
+        hash=sha256(content.encode("utf-8")).hexdigest(),
+    )
+    _SOURCE_DB[source_id] = metadata
+    return source_id
+
+
+def get_metadata(source_id: str) -> SourceMetadata | None:
+    """Return stored metadata for ``source_id`` if present."""
+
+    return _SOURCE_DB.get(source_id)
+
+
+__all__ = ["SourceMetadata", "get_metadata", "ingest_source"]

--- a/src/factsynth_ultimate/core/trace.py
+++ b/src/factsynth_ultimate/core/trace.py
@@ -1,0 +1,45 @@
+"""Simple trace object used to propagate ``source_id`` through the pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..tokenization import normalize
+from .source_store import ingest_source
+
+
+@dataclass
+class Trace:
+    """Trace information retained across processing stages."""
+
+    source_id: str
+    url: str
+    content: str
+
+
+def start_trace(url: str, content: str) -> Trace:
+    """Ingest *content* and return a new :class:`Trace` with ``source_id``."""
+
+    source_id = ingest_source(url, content)
+    return Trace(source_id=source_id, url=url, content=content)
+
+
+def parse(trace: Trace) -> Trace:
+    """Parsing stage placeholder keeping ``source_id`` intact."""
+
+    return trace
+
+
+def normalize_trace(trace: Trace) -> Trace:
+    """Normalize the trace content while preserving ``source_id``."""
+
+    trace.content = normalize(trace.content)
+    return trace
+
+
+def index(trace: Trace) -> Trace:
+    """Indexing stage placeholder preserving ``source_id``."""
+
+    return trace
+
+
+__all__ = ["Trace", "index", "normalize_trace", "parse", "start_trace"]

--- a/tests/test_evaluator_api.py
+++ b/tests/test_evaluator_api.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 from factsynth_ultimate.api import verify as verify_mod
 from factsynth_ultimate.services.evaluator import evaluate_claim
+from factsynth_ultimate.services.retriever import RetrievedDoc
 
 SCORING_RESULT = 0.5
 DIVERSITY_RESULT = 0.1
@@ -17,7 +18,7 @@ def test_evaluate_claim_composes_and_closes():
             self.closed = False
 
         def search(self, q):
-            return [(q, 1.0)]
+            return [RetrievedDoc(id=q, text=q, score=1.0)]
 
         def close(self):
             self.closed = True
@@ -37,7 +38,9 @@ def test_evaluate_claim_composes_and_closes():
     assert result["score"] == SCORING_RESULT
     assert result["diversity"] == DIVERSITY_RESULT
     assert result["nli"] == {"label": "neutral"}
-    assert result["evidence"] == [("alpha", 1.0)]
+    assert result["evidence"][0]["source"] == "alpha"
+    assert result["evidence"][0]["content"] == "alpha"
+    assert result["evidence"][0]["source_id"]
     assert retriever.closed
 
 

--- a/tests/test_factsynth_lock.py
+++ b/tests/test_factsynth_lock.py
@@ -9,7 +9,9 @@ pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def test_unknown_field_rejected():
     data = {
         "verdict": {"decision": "supported"},
-        "evidence": [{"source": "url", "content": "text"}],
+        "evidence": [
+            {"source_id": "1", "source": "url", "content": "text"}
+        ],
         "unexpected": "value",
     }
 

--- a/tests/test_factsynth_lock_contract.py
+++ b/tests/test_factsynth_lock_contract.py
@@ -9,7 +9,9 @@ pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def minimal_lock_data() -> dict:
     return {
         "verdict": {"decision": "supported"},
-        "evidence": [{"source": "url", "content": "text"}],
+        "evidence": [
+            {"source_id": "1", "source": "url", "content": "text"}
+        ],
     }
 
 

--- a/tests/test_quality_pipeline.py
+++ b/tests/test_quality_pipeline.py
@@ -19,7 +19,9 @@ def test_quality_pipeline_verify_returns_lock():
         "claim": "The earth orbits the sun",
         "lock": {
             "verdict": {"decision": "supported"},
-            "evidence": [{"source": "url", "content": "text"}],
+            "evidence": [
+                {"source_id": "1", "source": "url", "content": "text"}
+            ],
         },
     }
 


### PR DESCRIPTION
## Summary
- generate `source_id` during ingestion and retain metadata
- carry `source_id` through parsing, normalization, and indexing with a trace object
- include `source_id` in evidence so verdicts link back to ingested sources

## Testing
- `ruff check src/factsynth_ultimate/core/source_store.py src/factsynth_ultimate/core/trace.py src/factsynth_ultimate/core/factsynth_lock.py src/factsynth_ultimate/services/evaluator.py tests/test_factsynth_lock.py tests/test_factsynth_lock_contract.py tests/test_quality_pipeline.py tests/test_evaluator_api.py`
- `pytest tests/test_factsynth_lock.py tests/test_factsynth_lock_contract.py tests/test_quality_pipeline.py tests/test_evaluator_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68c571fa3bc8832983465856f304ca89