### PR TITLE
Add model and dataset cards

### DIFF
--- a/docs/datasets/golden_12.md
+++ b/docs/datasets/golden_12.md
@@ -1,0 +1,14 @@
+# Golden 12 Dataset Card
+
+## Source
+- Derived from `tests/golden_12.yaml` within this repository.
+
+## License
+- MIT License, inherited from the FactSynth project.
+
+## Known Biases
+- Composed of curated prompts and expectations; may reflect author assumptions.
+- Limited size and domain coverage reduce representativeness.
+
+## Version
+- 2.4 (matches dataset file)

--- a/docs/datasets/golden_factsynth.md
+++ b/docs/datasets/golden_factsynth.md
@@ -1,0 +1,14 @@
+# Golden FactSynth Dataset Card
+
+## Source
+- Derived from `tests/golden_factsynth.json` within this repository.
+
+## License
+- MIT License, inherited from the FactSynth project.
+
+## Known Biases
+- Contains hand-crafted task scenarios; may not represent real-world distributions.
+- Focuses on specific evaluation cases, limiting generalization.
+
+## Version
+- 1.0

--- a/docs/models/llm_arbitrator.md
+++ b/docs/models/llm_arbitrator.md
@@ -1,0 +1,16 @@
+# LLM Candidate Arbitrator Model Card
+
+## Goals
+- Select the best response from multiple language model candidates.
+- Balance response quality and context adherence via weighted scoring.
+
+## Data
+- Consumes candidate outputs produced by upstream LLMs.
+- No parameter training; uses simple deterministic scoring.
+
+## Limitations
+- Effectiveness depends on quality of provided candidate scores.
+- Linear weighting may not capture complex evaluation criteria.
+
+## Version
+- 1.0

--- a/docs/models/nli.md
+++ b/docs/models/nli.md
@@ -1,0 +1,16 @@
+# NLI Token Overlap Model Card
+
+## Goals
+- Lightweight natural language inference baseline.
+- Optional async classifier can be supplied by callers.
+
+## Data
+- No dedicated training set.
+- Operates directly on provided premise and hypothesis tokens.
+
+## Limitations
+- Relies on token overlap; unable to capture paraphrasing or deep semantics.
+- Falls back to heuristic scoring when classifier fails.
+
+## Version
+- 1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,3 +18,9 @@ nav:
   - Prompt Pack: PromptPack.md
   - Incubation Co-Dev UA: INCUBATION_CO_DEV_UA.md
   - FactSynth Lock: FACTSYNTH_LOCK.md
+  - Models:
+      - NLI Token Overlap: models/nli.md
+      - LLM Candidate Arbitrator: models/llm_arbitrator.md
+  - Datasets:
+      - Golden FactSynth: datasets/golden_factsynth.md
+      - Golden 12: datasets/golden_12.md


### PR DESCRIPTION
## Summary
- add model cards for NLI heuristic and LLM arbitrator
- add dataset cards for Golden FactSynth and Golden 12
- expose cards through MkDocs navigation

## Testing
- `pytest tests/test_nli.py tests/test_llm_ifc.py -q` *(fails: The following responses are mocked but not requested)*

------
https://chatgpt.com/codex/tasks/task_e_68c5720053d083299dee394f73515957