### PR TITLE
feat: add domain metadata schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -231,8 +231,36 @@ components:
           - type: string
           - type: 'null'
           title: Callback Url
+        domain:
+          anyOf:
+          - $ref: '#/components/schemas/DomainMetadata'
+          - type: 'null'
+          title: Domain
       type: object
       title: ScoreReq
+    DomainMetadata:
+      properties:
+        region:
+          type: string
+          minLength: 1
+          title: Region
+          x-strip-whitespace: true
+        language:
+          type: string
+          minLength: 1
+          title: Language
+          x-strip-whitespace: true
+        time_range:
+          type: string
+          minLength: 1
+          title: Time Range
+          x-strip-whitespace: true
+      required:
+      - region
+      - language
+      - time_range
+      type: object
+      title: DomainMetadata
     ValidationError:
       properties:
         loc:

--- a/src/factsynth_ultimate/schemas/requests.py
+++ b/src/factsynth_ultimate/schemas/requests.py
@@ -13,6 +13,14 @@ LargeInt = Annotated[int, Field(ge=1, le=10000)]
 Percent = Annotated[float, Field(ge=0.0, le=1.0)]
 
 
+class DomainMetadata(BaseModel):
+    """Domain attributes describing region, language and time span."""
+
+    region: StrippedNonEmpty
+    language: StrippedNonEmpty
+    time_range: StrippedNonEmpty
+
+
 class IntentReq(BaseModel):
     """Intent reflection request payload."""
 
@@ -26,6 +34,7 @@ class ScoreReq(BaseModel):
     text: NonNegativeStr = ""
     targets: list[StrippedNonEmpty] | None = None
     callback_url: str | None = None
+    domain: DomainMetadata | None = None
 
 
 class ScoreBatchReq(BaseModel):

--- a/tests/test_domain_metadata.py
+++ b/tests/test_domain_metadata.py
@@ -1,0 +1,17 @@
+import pytest
+from pydantic import ValidationError
+
+from factsynth_ultimate.schemas.requests import DomainMetadata, ScoreReq
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
+def test_domain_metadata_valid():
+    meta = DomainMetadata(region="eu", language="en", time_range="2020-2021")
+    req = ScoreReq(text="t", domain=meta)
+    assert req.domain == meta
+
+
+def test_domain_metadata_invalid_region():
+    with pytest.raises(ValidationError):
+        ScoreReq(text="t", domain={"region": "", "language": "en", "time_range": "2020"})


### PR DESCRIPTION
## Summary
- add DomainMetadata model and optional field on ScoreReq
- document domain attributes in OpenAPI schema
- cover domain metadata with unit tests

## Testing
- `pre-commit run --files src/factsynth_ultimate/schemas/requests.py openapi/openapi.yaml tests/test_domain_metadata.py` (fails: tests/test_validation_and_413.py::test_413_large_payload - AssertionError: The following responses are mocked but not requested, tests/test_validation_and_413.py::test_413_streamed_payload - AssertionError: The following responses are mocked but not requested, tests/test_webhook_retry.py::test_webhook_retry_failure - AssertionError: The following responses are mocked but not requested, tests/test_ws_stream.py::test_ws_stream_basic - AssertionError: The following responses are mocked but not requested, tests/test_api_key_prod.py::test_prod_env_requires_real_api_key[] - pydantic_core._pydantic_core.ValidationError: 1 validation error for Config, tests/test_callback_validation.py::test_invalid_callback_scheme - AssertionError: assert 'Callback URL...http or https' == 'Disallowed callback URL scheme', tests/test_callback_validation.py::test_invalid_callback_host - AssertionError: assert 'Callback URL... in allowlist' == 'Disallowed callback URL host', tests/test_ip_allowlist.py::test_missing_api_key_returns_401 - AssertionError: assert {'detail': 'M...horized', ...} == {'detail': 'M...'about:blank'}, tests/test_score_and_auth.py::test_auth_required - AssertionError: assert {'detail': 'M...horized', ...} == {'detail': 'M...'about:blank'} )
- `pytest tests/test_domain_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68c571b49640832989c70667baf19f72