### PR TITLE
feat: add domain metadata schema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -124,6 +124,13 @@ paths:
                     version: "1.1"
                     nonce: "abc123"
                     api_guard: "factsynth-lock/v1.1"
+                    verdict:
+                      decision: "confirmed"
+                      confidence: 0.9
+                    evidence:
+                      - source_id: "1"
+                        source: "url"
+                        content: "text"
       responses:
         '200':
           description: Verification result
@@ -137,6 +144,13 @@ paths:
                     version: "1.1"
                     nonce: "abc123"
                     api_guard: "factsynth-lock/v1.1"
+                    verdict:
+                      decision: "confirmed"
+                      confidence: 0.9
+                    evidence:
+                      - source_id: "1"
+                        source: "url"
+                        content: "text"
   /v1/healthz:
     get:
       summary: Healthz
@@ -231,8 +245,36 @@ components:
           - type: string
           - type: 'null'
           title: Callback Url
+        domain:
+          anyOf:
+          - $ref: '#/components/schemas/DomainMetadata'
+          - type: 'null'
+          title: Domain
       type: object
       title: ScoreReq
+    DomainMetadata:
+      properties:
+        region:
+          type: string
+          minLength: 1
+          title: Region
+          x-strip-whitespace: true
+        language:
+          type: string
+          minLength: 1
+          title: Language
+          x-strip-whitespace: true
+        time_range:
+          type: string
+          minLength: 1
+          title: Time Range
+          x-strip-whitespace: true
+      required:
+      - region
+      - language
+      - time_range
+      type: object
+      title: DomainMetadata
     ValidationError:
       properties:
         loc:
@@ -260,6 +302,8 @@ components:
         - version
         - nonce
         - api_guard
+        - verdict
+        - evidence
       properties:
         version:
           type: string
@@ -269,6 +313,38 @@ components:
         api_guard:
           type: string
           enum: ["factsynth-lock/v1.1"]
+        verdict:
+          type: object
+          required:
+            - decision
+          properties:
+            decision:
+              type: string
+              enum:
+                - confirmed
+                - refuted
+                - mixed
+                - not_enough_evidence
+                - not_a_fact
+            confidence:
+              type: number
+              minimum: 0
+              maximum: 1
+        evidence:
+          type: array
+          items:
+            type: object
+            required:
+              - source_id
+              - source
+              - content
+            properties:
+              source_id:
+                type: string
+              source:
+                type: string
+              content:
+                type: string
     VerifyRequest:
       type: object
       required:

--- a/prompts/factsynth_judge/DEPLOYMENT_NOTES.md
+++ b/prompts/factsynth_judge/DEPLOYMENT_NOTES.md
@@ -5,6 +5,6 @@
   3. Seed randomness.
   4. Record `METRICS`.
   5. Fail CI on schema violation or calibration regression.
-- **Monitoring**: Track `claims_supported/refuted/gap` ratios; alert on sudden confidence inflation.
+- **Monitoring**: Track `claims_confirmed/refuted/mixed/not_enough_evidence/not_a_fact` ratios; alert on sudden confidence inflation.
 - **Rollback**: Keep previous prompt under `prompts/fact_judge_<semver>.txt`.
 - **Extension points**: Plug a retrieval tool; add domain adapters (finance, bio, geo) with unit catalogs.

--- a/prompts/factsynth_judge/FEW_SHOTS/numeric_rounding_trap.md
+++ b/prompts/factsynth_judge/FEW_SHOTS/numeric_rounding_trap.md
@@ -1,3 +1,3 @@
 _Context_: "The crater's diameter is **99.6 km** according to the survey."
 _Question_: "Is the crater ~100 km wide?"
-_Expected_: `VERDICT: supported`, `NORMALIZATION: 99.6≈100 (±0.4%)`, confidence `likely`.
+_Expected_: `VERDICT: confirmed`, `NORMALIZATION: 99.6≈100 (±0.4%)`, confidence `likely`.

--- a/prompts/factsynth_judge/GOLDEN_12_TESTSET.json
+++ b/prompts/factsynth_judge/GOLDEN_12_TESTSET.json
@@ -2,7 +2,7 @@
   {
     "id": 1,
     "context": "",
-    "question": "Classification: Decide supported/refuted on a single factual claim with clear span.",
+    "question": "Classification: Decide confirmed/refuted on a single factual claim with clear span.",
     "expected": ""
   },
   {

--- a/prompts/factsynth_judge/SCHEMAS/output_contract.schema.json
+++ b/prompts/factsynth_judge/SCHEMAS/output_contract.schema.json
@@ -74,7 +74,13 @@
     },
     "VERDICT": {
       "type": "string",
-      "enum": ["supported", "partially_supported", "refuted", "not_provable"]
+      "enum": [
+        "confirmed",
+        "refuted",
+        "mixed",
+        "not_enough_evidence",
+        "not_a_fact"
+      ]
     },
     "NORMALIZATION": { "type": "string" },
     "CONFLICTS": { "type": "array", "items": { "type": "string" } },
@@ -85,17 +91,21 @@
       "required": [
         "latency_ms",
         "claims_total",
-        "claims_supported",
+        "claims_confirmed",
         "claims_refuted",
-        "claims_gap",
+        "claims_mixed",
+        "claims_not_enough_evidence",
+        "claims_not_a_fact",
         "calibration_hint"
       ],
       "properties": {
         "latency_ms": { "type": "number" },
         "claims_total": { "type": "integer" },
-        "claims_supported": { "type": "integer" },
+        "claims_confirmed": { "type": "integer" },
         "claims_refuted": { "type": "integer" },
-        "claims_gap": { "type": "integer" },
+        "claims_mixed": { "type": "integer" },
+        "claims_not_enough_evidence": { "type": "integer" },
+        "claims_not_a_fact": { "type": "integer" },
         "calibration_hint": { "type": "string" }
       }
     }

--- a/prompts/factsynth_judge/SYSTEM_PROMPT.md
+++ b/prompts/factsynth_judge/SYSTEM_PROMPT.md
@@ -12,7 +12,7 @@ IF–THEN BEHAVIOR RULES (EPAUP)
 - IF context is missing or insufficient → THEN return `EVIDENCE_GAP` with the smallest set of additional facts needed.
 - IF two sources conflict → THEN prefer the **most specific, most recent, and internally consistent** source; record the discarded alternative in `CONFLICTS`.
 - IF numbers/dates differ by rounding → THEN normalize and explain the delta in `NORMALIZATION`.
-- IF the user asks for a final answer that cannot be proven from context/tools → THEN return `NOT_PROVABLE` and provide a best-effort hypothesis separately in `HYPOTHESIS` (clearly labeled).
+- IF the user asks for a final answer that cannot be proven from context/tools → THEN return `NOT_ENOUGH_EVIDENCE` and provide a best-effort hypothesis separately in `HYPOTHESIS` (clearly labeled).
 
 TOOLS / WEB / CODE EXECUTION
 Default: **no external browsing**. If a retrieval/browse tool is enabled by the harness, call only to verify facts, never to expand scope. Every tool use must be cited in `EVIDENCE[].source`.
@@ -21,7 +21,7 @@ STYLE & SAFETY GUARDRAILS
 Terse, technical, no flourish. No speculation in `VERDICT`. No personal data. Refuse biased or harmful requests. Calibrate with confidence bands: `certain | likely | possible | unknown`.
 
 KPI & MONITORING HOOKS
-Emit metrics in `METRICS`: `{latency_ms, claims_total, claims_supported, claims_refuted, claims_gap, calibration_hint}` to support test assertions.
+Emit metrics in `METRICS`: `{latency_ms, claims_total, claims_confirmed, claims_refuted, claims_mixed, claims_not_enough_evidence, claims_not_a_fact, calibration_hint}` to support test assertions.
 
 OUTPUT CONTRACT (STRICT JSON)
 Return a single JSON object with these keys:
@@ -43,12 +43,12 @@ Return a single JSON object with these keys:
 "confidence": "certain|likely|possible|unknown"
 }
 ],
-"VERDICT": "supported|partially_supported|refuted|not_provable",
+"VERDICT": "confirmed|refuted|mixed|not_enough_evidence|not_a_fact",
 "NORMALIZATION": "note rounding/unit/date harmonization, if any",
 "CONFLICTS": "brief note or []",
-"HYPOTHESIS": "only if VERDICT is not_provable; otherwise empty string",
+"HYPOTHESIS": "only if VERDICT is not_enough_evidence; otherwise empty string",
 "EVIDENCE_GAP": [ "minimal additional facts needed, phrased as queries" ],
-"METRICS": { "latency_ms": 0, "claims_total": 0, "claims_supported": 0, "claims_refuted": 0, "claims_gap": 0, "calibration_hint": "…" }
+"METRICS": { "latency_ms": 0, "claims_total": 0, "claims_confirmed": 0, "claims_refuted": 0, "claims_mixed": 0, "claims_not_enough_evidence": 0, "claims_not_a_fact": 0, "calibration_hint": "…" }
 }
 
 UMAA+EPAUP PERSONALITY GRAMMAR (compressed)

--- a/src/factsynth_ultimate/core/factsynth_lock.py
+++ b/src/factsynth_ultimate/core/factsynth_lock.py
@@ -21,10 +21,11 @@ class _StrictModel(BaseModel):
 class Decision(str, Enum):
     """Possible outcomes of a claim evaluation."""
 
-    SUPPORTED = "supported"
-    PARTIALLY_SUPPORTED = "partially_supported"
+    CONFIRMED = "confirmed"
     REFUTED = "refuted"
-    NOT_PROVABLE = "not_provable"
+    MIXED = "mixed"
+    NOT_ENOUGH_EVIDENCE = "not_enough_evidence"
+    NOT_A_FACT = "not_a_fact"
 
 
 class Verdict(_StrictModel):
@@ -67,4 +68,3 @@ class FactSynthLock(_StrictModel):
 
 
 __all__ = ["Decision", "Evidence", "FactSynthLock", "Verdict"]
-

--- a/src/factsynth_ultimate/schemas/requests.py
+++ b/src/factsynth_ultimate/schemas/requests.py
@@ -13,6 +13,14 @@ LargeInt = Annotated[int, Field(ge=1, le=10000)]
 Percent = Annotated[float, Field(ge=0.0, le=1.0)]
 
 
+class DomainMetadata(BaseModel):
+    """Domain attributes describing region, language and time span."""
+
+    region: StrippedNonEmpty
+    language: StrippedNonEmpty
+    time_range: StrippedNonEmpty
+
+
 class IntentReq(BaseModel):
     """Intent reflection request payload."""
 
@@ -26,6 +34,7 @@ class ScoreReq(BaseModel):
     text: NonNegativeStr = ""
     targets: list[StrippedNonEmpty] | None = None
     callback_url: str | None = None
+    domain: DomainMetadata | None = None
 
 
 class ScoreBatchReq(BaseModel):

--- a/tests/test_domain_metadata.py
+++ b/tests/test_domain_metadata.py
@@ -1,0 +1,17 @@
+import pytest
+from pydantic import ValidationError
+
+from factsynth_ultimate.schemas.requests import DomainMetadata, ScoreReq
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
+def test_domain_metadata_valid():
+    meta = DomainMetadata(region="eu", language="en", time_range="2020-2021")
+    req = ScoreReq(text="t", domain=meta)
+    assert req.domain == meta
+
+
+def test_domain_metadata_invalid_region():
+    with pytest.raises(ValidationError):
+        ScoreReq(text="t", domain={"region": "", "language": "en", "time_range": "2020"})

--- a/tests/test_factsynth_lock.py
+++ b/tests/test_factsynth_lock.py
@@ -8,10 +8,8 @@ pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 def test_unknown_field_rejected():
     data = {
-        "verdict": {"decision": "supported"},
-        "evidence": [
-            {"source_id": "1", "source": "url", "content": "text"}
-        ],
+        "verdict": {"decision": "confirmed"},
+        "evidence": [{"source_id": "1", "source": "url", "content": "text"}],
         "unexpected": "value",
     }
 
@@ -26,11 +24,11 @@ def test_invalid_decision_rejected():
 
 def test_verdict_rejects_unknown_field():
     with pytest.raises(ValidationError):
-        Verdict.model_validate({"decision": Decision.SUPPORTED, "extra": "value"})
+        Verdict.model_validate({"decision": Decision.CONFIRMED, "extra": "value"})
 
 
 def test_lock_requires_evidence():
-    data = {"verdict": {"decision": "supported"}, "evidence": []}
+    data = {"verdict": {"decision": "confirmed"}, "evidence": []}
 
     with pytest.raises(ValidationError):
         FactSynthLock.model_validate(data)

--- a/tests/test_factsynth_lock_contract.py
+++ b/tests/test_factsynth_lock_contract.py
@@ -8,10 +8,8 @@ pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 def minimal_lock_data() -> dict:
     return {
-        "verdict": {"decision": "supported"},
-        "evidence": [
-            {"source_id": "1", "source": "url", "content": "text"}
-        ],
+        "verdict": {"decision": "confirmed"},
+        "evidence": [{"source_id": "1", "source": "url", "content": "text"}],
     }
 
 

--- a/tests/test_quality_pipeline.py
+++ b/tests/test_quality_pipeline.py
@@ -18,10 +18,8 @@ def test_quality_pipeline_verify_returns_lock():
     payload = {
         "claim": "The earth orbits the sun",
         "lock": {
-            "verdict": {"decision": "supported"},
-            "evidence": [
-                {"source_id": "1", "source": "url", "content": "text"}
-            ],
+            "verdict": {"decision": "confirmed"},
+            "evidence": [{"source_id": "1", "source": "url", "content": "text"}],
         },
     }
 


### PR DESCRIPTION
## Summary
- add DomainMetadata model and optional field on ScoreReq
- document domain attributes in OpenAPI schema
- cover domain metadata with unit tests
- introduce standardized verdict taxonomy and propagate to OpenAPI and prompt contracts

## Testing
- `pre-commit run --files src/factsynth_ultimate/core/factsynth_lock.py tests/test_factsynth_lock.py tests/test_factsynth_lock_contract.py tests/test_quality_pipeline.py openapi/openapi.yaml prompts/factsynth_judge/SCHEMAS/output_contract.schema.json prompts/factsynth_judge/SYSTEM_PROMPT.md prompts/factsynth_judge/FEW_SHOTS/numeric_rounding_trap.md prompts/factsynth_judge/GOLDEN_12_TESTSET.json prompts/factsynth_judge/DEPLOYMENT_NOTES.md` (fails: tests/test_auth.py missing dependencies)
- `pytest tests/test_factsynth_lock.py tests/test_factsynth_lock_contract.py tests/test_quality_pipeline.py tests/test_domain_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68c571b49640832989c70667baf19f72