### PR TITLE
validate score request requires text or targets

### DIFF
--- a/docs/PromptPack.md
+++ b/docs/PromptPack.md
@@ -29,7 +29,7 @@ IF–THEN BEHAVIOR RULES
 
 TOOL USE (HTTP wrappers assumed)
 - POST /v1/intent_reflector {intent,length}
-- POST /v1/score {text,targets}|/v1/score/batch
+- POST /v1/score {text?,targets?}|/v1/score/batch (requires one of text or targets)
 - POST /v1/generate {text,max_len,max_sentences,include_score}
 - POST /v1/stream (SSE) or WS /ws/stream for token events
 - GET /v1/version, /metrics (no auth), Problem+JSON on errors

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -42,6 +42,7 @@ paths:
   /v1/score:
     post:
       summary: Score
+      description: At least one of 'text' or 'targets' must be non-empty.
       operationId: score_v1_score_post
       requestBody:
         content:
@@ -238,6 +239,7 @@ components:
               minLength: 1
               x-strip-whitespace: true
             type: array
+            minItems: 1
           - type: 'null'
           title: Targets
         callback_url:
@@ -252,6 +254,7 @@ components:
           title: Domain
       type: object
       title: ScoreReq
+      description: At least one of 'text' or 'targets' must be non-empty.
     DomainMetadata:
       properties:
         region:

--- a/prompts/SYSTEM_PROMPT.md
+++ b/prompts/SYSTEM_PROMPT.md
@@ -35,7 +35,7 @@ Maximize factual signal and observability while minimizing noise. Transform raw 
 
 - factsynth.version → GET `/v1/version`
 - factsynth.intent_reflector → POST `/v1/intent_reflector` `{intent:str, length:int}`
-- factsynth.score → POST `/v1/score` `{text:str, targets:list[str]}`
+- factsynth.score → POST `/v1/score` `{text?:str, targets?:list[str]}` (text or targets required)
 - factsynth.score_batch → POST `/v1/score/batch` `{items:list[{text,targets?}], webhook_url?:str}`
 - factsynth.stream_sse → POST `/v1/stream` `{text:str}` (SSE)
 - factsynth.generate → POST `/v1/generate` `{text:str, max_len?:int, max_sentences?:int, include_score?:bool}`

--- a/src/factsynth_ultimate/schemas/requests.py
+++ b/src/factsynth_ultimate/schemas/requests.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 StrippedNonEmpty = Annotated[str, Field(strip_whitespace=True, min_length=1)]
 NonNegativeStr = Annotated[str, Field(strip_whitespace=True, min_length=0)]
@@ -35,6 +35,12 @@ class ScoreReq(BaseModel):
     targets: list[StrippedNonEmpty] | None = None
     callback_url: str | None = None
     domain: DomainMetadata | None = None
+
+    @model_validator(mode="after")
+    def _require_text_or_targets(self) -> ScoreReq:
+        if not self.text and not self.targets:
+            raise ValueError("either 'text' or 'targets' must be provided")
+        return self
 
 
 class ScoreBatchReq(BaseModel):

--- a/tests/test_domain_metadata.py
+++ b/tests/test_domain_metadata.py
@@ -15,3 +15,17 @@ def test_domain_metadata_valid():
 def test_domain_metadata_invalid_region():
     with pytest.raises(ValidationError):
         ScoreReq(text="t", domain={"region": "", "language": "en", "time_range": "2020"})
+
+
+@pytest.mark.parametrize("kwargs", [
+    {},
+    {"targets": []},
+])
+def test_score_req_requires_text_or_targets(kwargs):
+    with pytest.raises(ValidationError):
+        ScoreReq(**kwargs)
+
+
+def test_score_req_accepts_text_or_targets():
+    assert ScoreReq(text="x").text == "x"
+    assert ScoreReq(targets=["a"]).targets == ["a"]


### PR DESCRIPTION
## Summary
- require at least one of `text` or `targets` in `ScoreReq`
- test score request validation for empty payloads
- document request requirement in OpenAPI spec and prompts

## Testing
- `ruff check src/factsynth_ultimate/schemas/requests.py tests/test_domain_metadata.py`
- `pytest tests/test_domain_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5873cd5348329acd03c4dfeb2dd0d