### PR TITLE
feat: add TTL-based source store retention with optional Redis backend

### DIFF
--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -23,14 +23,15 @@ class Settings(BaseSettings):
     skip_auth_paths: list[str] = Field(
         default_factory=lambda: ["/v1/healthz", "/metrics"], env="SKIP_AUTH_PATHS"
     )
-    callback_url_allowed_hosts: str = Field(
-        default="", env="CALLBACK_URL_ALLOWED_HOSTS"
-    )
+    callback_url_allowed_hosts: str = Field(default="", env="CALLBACK_URL_ALLOWED_HOSTS")
     rate_limit_redis_url: str = Field(env="RATE_LIMIT_REDIS_URL")
     rate_limit_per_key: int = Field(default=120, env="RATE_LIMIT_PER_KEY")
     rate_limit_per_ip: int = Field(default=120, env="RATE_LIMIT_PER_IP")
     rate_limit_per_org: int = Field(default=120, env="RATE_LIMIT_PER_ORG")
     health_tcp_checks: list[str] = Field(default_factory=list, env="HEALTH_TCP_CHECKS")
+    source_store_backend: str = Field(default="memory", env="SOURCE_STORE_BACKEND")
+    source_store_ttl_seconds: int | None = Field(default=3600, env="SOURCE_STORE_TTL_SECONDS")
+    source_store_redis_url: str | None = Field(default=None, env="SOURCE_STORE_REDIS_URL")
 
     @field_validator(
         "cors_allow_origins",
@@ -52,4 +53,3 @@ def load_settings() -> Settings:
     """Load settings from environment variables."""
 
     return Settings()
-

--- a/src/factsynth_ultimate/core/source_store.py
+++ b/src/factsynth_ultimate/core/source_store.py
@@ -1,11 +1,16 @@
-"""In-memory source metadata store and ingestion helpers."""
+"""Source metadata store with optional TTL eviction or persistent backend."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from hashlib import sha256
+from typing import Protocol
 from uuid import uuid4
+
+import redis
+
+from .settings import load_settings
 
 
 @dataclass
@@ -17,40 +22,120 @@ class SourceMetadata:
     hash: str
 
 
-# Simple in-memory store for source metadata
-_SOURCE_DB: dict[str, SourceMetadata] = {}
+class SourceStore(Protocol):
+    """Protocol describing store operations."""
+
+    def ingest_source(self, url: str, content: str) -> str: ...
+
+    def get_metadata(self, source_id: str) -> SourceMetadata | None: ...
+
+    def cleanup(self) -> None: ...
+
+
+class MemorySourceStore:
+    """In-memory store with optional TTL support."""
+
+    def __init__(self, ttl: int | None = None):
+        self._db: dict[str, tuple[SourceMetadata, datetime | None]] = {}
+        self.ttl = ttl
+
+    def ingest_source(self, url: str, content: str) -> str:
+        source_id = uuid4().hex
+        metadata = SourceMetadata(
+            url=url,
+            date=datetime.now(UTC).isoformat(),
+            hash=sha256(content.encode("utf-8")).hexdigest(),
+        )
+        expires = datetime.now(UTC) + timedelta(seconds=self.ttl) if self.ttl is not None else None
+        self._db[source_id] = (metadata, expires)
+        return source_id
+
+    def get_metadata(self, source_id: str) -> SourceMetadata | None:
+        item = self._db.get(source_id)
+        if not item:
+            return None
+        metadata, expires = item
+        if expires and datetime.now(UTC) >= expires:
+            del self._db[source_id]
+            return None
+        return metadata
+
+    def cleanup(self) -> None:
+        if not self.ttl:
+            return
+        now = datetime.now(UTC)
+        expired = [k for k, (_, exp) in self._db.items() if exp and exp <= now]
+        for key in expired:
+            del self._db[key]
+
+
+class RedisSourceStore:
+    """Redis-backed store relying on Redis for TTL management."""
+
+    def __init__(self, redis_client, ttl: int | None = None):
+        self.redis = redis_client
+        self.ttl = ttl
+
+    def ingest_source(self, url: str, content: str) -> str:
+        source_id = uuid4().hex
+        metadata = SourceMetadata(
+            url=url,
+            date=datetime.now(UTC).isoformat(),
+            hash=sha256(content.encode("utf-8")).hexdigest(),
+        )
+        self.redis.hset(source_id, mapping=metadata.__dict__)
+        if self.ttl:
+            self.redis.expire(source_id, self.ttl)
+        return source_id
+
+    def get_metadata(self, source_id: str) -> SourceMetadata | None:
+        data = self.redis.hgetall(source_id)
+        if not data:
+            return None
+        return SourceMetadata(
+            url=data[b"url"].decode(),
+            date=data[b"date"].decode(),
+            hash=data[b"hash"].decode(),
+        )
+
+    def cleanup(self) -> None:  # pragma: no cover - Redis handles TTL itself
+        return
+
+
+def _build_store() -> SourceStore:
+    settings = load_settings()
+    if settings.source_store_backend == "redis":
+        client = redis.from_url(settings.source_store_redis_url or "redis://localhost")
+        return RedisSourceStore(client, ttl=settings.source_store_ttl_seconds)
+    return MemorySourceStore(ttl=settings.source_store_ttl_seconds)
+
+
+_STORE: SourceStore = _build_store()
 
 
 def ingest_source(url: str, content: str) -> str:
-    """Generate a unique ``source_id`` and persist metadata.
+    """Generate a unique ``source_id`` and persist metadata."""
 
-    Parameters
-    ----------
-    url:
-        Original location of the content.
-    content:
-        Raw content used to generate a stable hash.
-
-    Returns
-    -------
-    str
-        The generated ``source_id``.
-    """
-
-    source_id = uuid4().hex
-    metadata = SourceMetadata(
-        url=url,
-        date=datetime.now(UTC).isoformat(),
-        hash=sha256(content.encode("utf-8")).hexdigest(),
-    )
-    _SOURCE_DB[source_id] = metadata
-    return source_id
+    return _STORE.ingest_source(url, content)
 
 
 def get_metadata(source_id: str) -> SourceMetadata | None:
     """Return stored metadata for ``source_id`` if present."""
 
-    return _SOURCE_DB.get(source_id)
+    return _STORE.get_metadata(source_id)
 
 
-__all__ = ["SourceMetadata", "get_metadata", "ingest_source"]
+def cleanup_expired_entries() -> None:
+    """Remove expired entries for in-memory backend."""
+
+    _STORE.cleanup()
+
+
+__all__ = [
+    "MemorySourceStore",
+    "RedisSourceStore",
+    "SourceMetadata",
+    "cleanup_expired_entries",
+    "get_metadata",
+    "ingest_source",
+]

--- a/tests/test_source_store.py
+++ b/tests/test_source_store.py
@@ -1,0 +1,25 @@
+import time
+
+import fakeredis
+import pytest
+
+from factsynth_ultimate.core.source_store import MemorySourceStore, RedisSourceStore
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_memory_store_ttl_cleanup():
+    store = MemorySourceStore(ttl=1)
+    sid = store.ingest_source("http://example.com", "payload")
+    assert store.get_metadata(sid) is not None
+    time.sleep(1.1)
+    store.cleanup()
+    assert store.get_metadata(sid) is None
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_redis_store_persists_entries():
+    redis_client = fakeredis.FakeRedis()
+    store = RedisSourceStore(redis_client, ttl=None)
+    sid = store.ingest_source("http://example.com", "payload")
+    new_store = RedisSourceStore(redis_client, ttl=None)
+    assert new_store.get_metadata(sid) is not None


### PR DESCRIPTION
## Summary
- add configurable retention and backend settings for source store
- implement in-memory TTL eviction and Redis-backed persistence
- test cleanup behavior for memory and Redis stores

## Testing
- `ruff check src/factsynth_ultimate/core/source_store.py src/factsynth_ultimate/core/settings.py tests/test_source_store.py`
- `black --check tests/test_source_store.py src/factsynth_ultimate/core/source_store.py src/factsynth_ultimate/core/settings.py`
- `pytest tests/test_source_store.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5873e33588329b6e3468f653b45ce