### PR TITLE
Integrate evaluator results into verification lock

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -126,7 +126,6 @@ paths:
                     api_guard: "factsynth-lock/v1.1"
                     verdict:
                       decision: "confirmed"
-                      confidence: 0.9
                     evidence:
                       - source_id: "1"
                         source: "url"
@@ -148,9 +147,9 @@ paths:
                       decision: "confirmed"
                       confidence: 0.9
                     evidence:
-                      - source_id: "1"
-                        source: "url"
-                        content: "text"
+                      - source_id: "99"
+                        source: "https://example.com"
+                        content: "astronomical observation"
   /v1/healthz:
     get:
       summary: Healthz

--- a/src/factsynth_ultimate/api/verify.py
+++ b/src/factsynth_ultimate/api/verify.py
@@ -12,7 +12,14 @@ api = APIRouter()
 
 @api.post("/verify", response_model=FactSynthLock)
 def verify(req: VerifyRequest) -> FactSynthLock:
-    """Verify a claim and return the provided lock."""
+    """Verify a claim and merge evaluation results into the lock."""
 
-    evaluate_claim(req.claim)
-    return req.lock
+    evaluation = evaluate_claim(req.claim)
+    lock_data = req.lock.model_dump()
+
+    if verdict := evaluation.get("verdict"):
+        lock_data["verdict"] = verdict
+    if evidence := evaluation.get("evidence"):
+        lock_data["evidence"] = evidence
+
+    return FactSynthLock.model_validate(lock_data)


### PR DESCRIPTION
## Summary
- merge evaluation output into lock when verifying claims
- test that evaluator results affect returned lock
- document enriched verification response in OpenAPI examples

## Testing
- `pytest tests/test_quality_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5873fa6ec83299d6e0c996f744cbd