### PR TITLE
Add trust and expiration handling to source metadata

### DIFF
--- a/src/factsynth_ultimate/core/trace.py
+++ b/src/factsynth_ultimate/core/trace.py
@@ -1,7 +1,9 @@
 """Simple trace object used to propagate ``source_id`` through the pipeline."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from ..tokenization import normalize
 from .source_store import ingest_source
@@ -16,10 +18,15 @@ class Trace:
     content: str
 
 
-def start_trace(url: str, content: str) -> Trace:
+def start_trace(
+    url: str,
+    content: str,
+    trust: float = 1.0,
+    expires_at: datetime | None = None,
+) -> Trace:
     """Ingest *content* and return a new :class:`Trace` with ``source_id``."""
 
-    source_id = ingest_source(url, content)
+    source_id = ingest_source(url, content, trust, expires_at)
     return Trace(source_id=source_id, url=url, content=content)
 
 

--- a/tests/test_source_store.py
+++ b/tests/test_source_store.py
@@ -1,4 +1,5 @@
 import time
+from datetime import UTC, datetime, timedelta
 
 import fakeredis
 import pytest
@@ -9,10 +10,9 @@ from factsynth_ultimate.core.source_store import MemorySourceStore, RedisSourceS
 @pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 def test_memory_store_ttl_cleanup():
     store = MemorySourceStore(ttl=1)
-    sid = store.ingest_source("http://example.com", "payload")
+    sid = store.ingest_source("http://example.com", "payload", trust=0.9)
     assert store.get_metadata(sid) is not None
     time.sleep(1.1)
-    store.cleanup()
     assert store.get_metadata(sid) is None
 
 
@@ -20,6 +20,21 @@ def test_memory_store_ttl_cleanup():
 def test_redis_store_persists_entries():
     redis_client = fakeredis.FakeRedis()
     store = RedisSourceStore(redis_client, ttl=None)
-    sid = store.ingest_source("http://example.com", "payload")
+    sid = store.ingest_source("http://example.com", "payload", trust=0.9)
     new_store = RedisSourceStore(redis_client, ttl=None)
     assert new_store.get_metadata(sid) is not None
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_low_trust_pruned():
+    store = MemorySourceStore(min_trust=0.5)
+    sid = store.ingest_source("http://example.com", "payload", trust=0.1)
+    assert store.get_metadata(sid) is None
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_expired_entry_pruned():
+    store = MemorySourceStore()
+    expired = datetime.now(UTC) - timedelta(seconds=1)
+    sid = store.ingest_source("http://example.com", "payload", trust=0.9, expires_at=expired)
+    assert store.get_metadata(sid) is None


### PR DESCRIPTION
## Summary
- track trust and optional expiration on stored sources
- evict expired or low-trust sources during ingestion and retrieval
- cover pruning behaviour with unit tests

## Testing
- `pre-commit run --files src/factsynth_ultimate/core/source_store.py src/factsynth_ultimate/core/trace.py tests/test_source_store.py` *(fails: ERROR tests/test_validation_and_413.py::test_score_validation_ok - AssertionError: The following responses are mocked but not requested:)*
- `pytest tests/test_source_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68c58bb03464832983baf14f9ed15959