### PR TITLE
Add PII redaction helper

### DIFF
--- a/src/factsynth_ultimate/services/evaluator.py
+++ b/src/factsynth_ultimate/services/evaluator.py
@@ -8,6 +8,7 @@ from contextlib import ExitStack
 from typing import Any
 
 from ..core.trace import index, normalize_trace, parse, start_trace
+from .redaction import redact_pii
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,7 @@ def evaluate_claim(  # noqa: PLR0913
             for doc in docs:
                 url = getattr(doc, "id", "")
                 content = getattr(doc, "text", "")
+                content = redact_pii(content)
                 trace = start_trace(url, content)
                 trace = parse(trace)
                 trace = normalize_trace(trace)

--- a/src/factsynth_ultimate/services/redaction.py
+++ b/src/factsynth_ultimate/services/redaction.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Utilities for removing personally identifiable information from text."""
+
+import re
+
+# Regular expressions covering common PII patterns
+_EMAIL_RE = re.compile(r"\b[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)*\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b")
+_SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+
+def redact_pii(text: str) -> str:
+    """Replace common PII patterns in *text* with placeholders.
+
+    Parameters
+    ----------
+    text:
+        The input string that may contain PII.
+
+    Returns
+    -------
+    str
+        ``text`` with e-mail addresses, phone numbers and social security
+        numbers replaced by redaction tokens.
+    """
+
+    text = _EMAIL_RE.sub("[REDACTED_EMAIL]", text)
+    text = _PHONE_RE.sub("[REDACTED_PHONE]", text)
+    text = _SSN_RE.sub("[REDACTED_SSN]", text)
+    return text
+
+
+__all__ = ["redact_pii"]

--- a/tests/test_redact_pii.py
+++ b/tests/test_redact_pii.py
@@ -1,0 +1,35 @@
+import pytest
+
+from factsynth_ultimate.services.redaction import redact_pii
+from factsynth_ultimate.services.evaluator import evaluate_claim
+from factsynth_ultimate.services.retriever import RetrievedDoc
+
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
+def test_redact_email():
+    text = "Contact me at test@example.com for details."
+    assert redact_pii(text) == "Contact me at [REDACTED_EMAIL] for details."
+
+
+def test_redact_phone():
+    text = "Call me at 123-456-7890 tomorrow."
+    assert redact_pii(text) == "Call me at [REDACTED_PHONE] tomorrow."
+
+
+def test_redact_ssn():
+    text = "SSN 123-45-6789 should be private."
+    assert redact_pii(text) == "SSN [REDACTED_SSN] should be private."
+
+
+def test_evaluate_claim_redacts_evidence_content():
+    class DummyRetriever:
+        def search(self, q):
+            return [RetrievedDoc(id="src", text="Email test@example.com now", score=1.0)]
+
+        def close(self):  # pragma: no cover - no-op
+            pass
+
+    result = evaluate_claim("alpha", retriever=DummyRetriever())
+    assert result["evidence"][0]["content"] == "Email [REDACTED_EMAIL] now"


### PR DESCRIPTION
## Summary
- sanitize evidence text by filtering common PII patterns
- call `redact_pii` in evaluator before tracing
- test email/phone/SSN redaction and evidence integration

## Testing
- `pytest tests/test_evaluator_api.py tests/test_redact_pii.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c58bb3352883299b7e57fc08ffcfaf