### PR TITLE
feat: validate domain metadata formats

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -258,15 +258,18 @@ components:
           pattern: '^[A-Z]{2}$'
           title: Region
           description: ISO 3166-1 alpha-2 code
+          example: US
         language:
           type: string
           pattern: '^[a-z]{2}$'
           title: Language
           description: ISO 639-1 code
+          example: en
         time_range:
           oneOf:
             - type: string
               pattern: '^\\d{4}-\\d{2}-\\d{2}/\\d{4}-\\d{2}-\\d{2}$'
+              example: '2020-01-01/2020-12-31'
             - type: object
               required:
                 - start
@@ -275,9 +278,11 @@ components:
                 start:
                   type: string
                   format: date
+                  example: '2020-01-01'
                 end:
                   type: string
                   format: date
+                  example: '2020-12-31'
           title: Time Range
       required:
       - region

--- a/tests/test_domain_metadata.py
+++ b/tests/test_domain_metadata.py
@@ -39,3 +39,13 @@ def test_domain_metadata_malformed_time_range_object():
             time_range={"start": "2020-01-01"},
         )
 
+
+def test_domain_metadata_invalid_region_format():
+    with pytest.raises(ValidationError):
+        DomainMetadata(region="USA", language="en", time_range="2020-01-01/2020-12-31")
+
+
+def test_domain_metadata_time_range_end_before_start():
+    with pytest.raises(ValidationError):
+        DomainMetadata(region="US", language="en", time_range="2020-12-31/2020-01-01")
+


### PR DESCRIPTION
## Summary
- add regex constants and ordering validation for `DomainMetadata`
- document ISO code and time range examples in OpenAPI spec
- expand tests for invalid codes and malformed ranges

## Testing
- `ruff check src/factsynth_ultimate/schemas/requests.py tests/test_domain_metadata.py`
- `pytest tests/test_domain_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68c58bb7a0e48329afe339161f53b357