### PR TITLE
Handle async retriever closure in evaluator

### DIFF
--- a/tests/test_evaluator_api.py
+++ b/tests/test_evaluator_api.py
@@ -65,6 +65,44 @@ def test_evaluate_claim_handles_retriever_exception_and_closes():
     assert retriever.closed
 
 
+def test_evaluate_claim_closes_async_retriever():
+    class DummyRetriever:
+        def __init__(self):
+            self.closed = False
+
+        def search(self, _):
+            return []
+
+        async def aclose(self):
+            self.closed = True
+
+    retriever = DummyRetriever()
+
+    result = evaluate_claim("gamma", retriever=retriever)
+
+    assert result["evidence"] == []
+    assert retriever.closed
+
+
+def test_evaluate_claim_handles_async_retriever_exception_and_closes():
+    class DummyRetriever:
+        def __init__(self):
+            self.closed = False
+
+        def search(self, _):
+            raise RuntimeError("boom")
+
+        async def aclose(self):
+            self.closed = True
+
+    retriever = DummyRetriever()
+
+    result = evaluate_claim("delta", retriever=retriever)
+
+    assert result["evidence"] == []
+    assert retriever.closed
+
+
 def test_evaluate_claim_logs_retriever_exception(caplog):
     class DummyRetriever:
         def search(self, _):


### PR DESCRIPTION
## Summary
- Support asynchronous retriever cleanup with `aclose` in `evaluate_claim`
- Test asynchronous retriever closure paths

## Testing
- `SKIP=pytest pre-commit run --files src/factsynth_ultimate/services/evaluator.py tests/test_evaluator_api.py`
- `pytest tests/test_evaluator_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5af5514e483299f7db27199717083