### PR TITLE
Cache allowed callback hosts

### DIFF
--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
 import random
@@ -47,6 +48,7 @@ logger = logging.getLogger(__name__)
 ALLOWED_CALLBACK_SCHEMES = {"http", "https"}
 
 
+@functools.lru_cache
 def get_allowed_hosts() -> set[str]:
     """Return the set of allowed callback hosts."""
     from ..core.settings import load_settings


### PR DESCRIPTION
## Summary
- cache allowed callback hosts to avoid repeated settings loads
- test callback URL validation with cached hosts and configuration changes

## Testing
- `pre-commit run --files src/factsynth_ultimate/api/routers.py tests/test_validate_callback_url.py` *(fails: ModuleNotFoundError: No module named 'hypothesis'; ModuleNotFoundError: No module named 'fakeredis')*
- `pytest tests/test_validate_callback_url.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5af55129c83298b18b5045b0d53c1