### PR TITLE
feat: make token delay configurable

### DIFF
--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -172,9 +172,12 @@ def feedback(req: FeedbackReq, request: Request) -> dict[str, str]:
 
 
 @api.post("/v1/stream")
-async def stream(req: ScoreReq, request: Request) -> StreamingResponse:  # noqa: C901
+async def stream(
+    req: ScoreReq, request: Request, token_delay: float | None = None
+) -> StreamingResponse:  # noqa: C901
     """Stream tokenized preview of ``req.text`` using Server-Sent Events."""
 
+    delay = token_delay if token_delay is not None else load_config().token_delay
     tokens = tokenize_preview(req.text, max_tokens=256) or ["factsynth"]
     resources: list[object] = []
     for obj in (
@@ -192,7 +195,7 @@ async def stream(req: ScoreReq, request: Request) -> StreamingResponse:  # noqa:
         try:
             yield "event: start\n" + "data: {}\n\n"
             for t in tokens:
-                await asyncio.sleep(0.002)
+                await asyncio.sleep(delay)
                 if await request.is_disconnected():
                     break
                 sent += 1

--- a/src/factsynth_ultimate/core/config.py
+++ b/src/factsynth_ultimate/core/config.py
@@ -26,6 +26,7 @@ class Config(BaseSettings):
     rate_limit_per_key: int = Field(default=120, env="RATE_LIMIT_PER_KEY")
     rate_limit_per_ip: int = Field(default=120, env="RATE_LIMIT_PER_IP")
     rate_limit_per_org: int = Field(default=120, env="RATE_LIMIT_PER_ORG")
+    token_delay: float = Field(default=0.002, env="TOKEN_DELAY")
 
     @field_validator("ip_allowlist", "cors_origins", "allowed_api_keys", mode="before")
     @classmethod
@@ -55,6 +56,13 @@ class Config(BaseSettings):
     def _non_negative(cls, value: int) -> int:
         if value < 0:
             raise ValueError("Rate limits must be non-negative")
+        return value
+
+    @field_validator("token_delay")
+    @classmethod
+    def _non_negative_delay(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("token_delay must be non-negative")
         return value
 
 

--- a/tests/test_stream_sse.py
+++ b/tests/test_stream_sse.py
@@ -3,6 +3,9 @@ from http import HTTPStatus
 import pytest
 
 
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
 @pytest.mark.anyio
 @pytest.mark.smoke
 async def test_sse_stream_basic(client, base_headers):
@@ -13,3 +16,23 @@ async def test_sse_stream_basic(client, base_headers):
         assert "text/event-stream" in r.headers.get("content-type", "")
         first = await r.aiter_bytes().__anext__()
         assert b"data:" in first or b"event:" in first
+
+
+@pytest.mark.anyio
+async def test_sse_stream_custom_token_delay(client, base_headers, monkeypatch):
+    calls: list[float] = []
+
+    async def fake_sleep(value: float) -> None:  # pragma: no cover - behavior verified via calls
+        calls.append(value)
+
+    monkeypatch.setattr("factsynth_ultimate.api.routers.asyncio.sleep", fake_sleep)
+    async with client.stream(
+        "POST",
+        "/v1/stream?token_delay=0.01",
+        headers=base_headers,
+        json={"text": "delayed"},
+    ) as r:
+        assert r.status_code == HTTPStatus.OK
+        await r.aread()
+
+    assert calls and all(call == pytest.approx(0.01) for call in calls)


### PR DESCRIPTION
## Summary
- allow `token_delay` in `/v1/stream` endpoint and use config default
- expose configurable `token_delay` in `Config`
- test custom SSE token delay behavior

## Testing
- `pytest tests/test_stream_sse.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5af56571c8329bf736db8fa85680e