### PR TITLE
Handle optional JAX and Diffrax dependencies

### DIFF
--- a/src/factsynth_ultimate/isr/sim.py
+++ b/src/factsynth_ultimate/isr/sim.py
@@ -5,8 +5,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
-import jax.numpy as jnp
-from diffrax import ODETerm, SaveAt, Tsit5, diffeqsolve
+try:
+    import jax.numpy as jnp
+except ImportError as exc:  # pragma: no cover - runtime dependency check
+    raise RuntimeError(
+        "JAX is required for ISR simulations. Install with `pip install jax`"
+    ) from exc
+
+try:
+    from diffrax import ODETerm, SaveAt, Tsit5, diffeqsolve
+except ImportError as exc:  # pragma: no cover - runtime dependency check
+    raise RuntimeError(
+        "Diffrax is required for ISR simulations. Install with `pip install diffrax`"
+    ) from exc
 
 GAMMA_FREQ = 40.0
 

--- a/tests/test_isr.py
+++ b/tests/test_isr.py
@@ -1,3 +1,6 @@
+import importlib
+import sys
+
 import pytest
 
 diffrax = pytest.importorskip("diffrax")
@@ -18,9 +21,26 @@ MIN_DOM_FREQ = 0.0
 MAX_DOM_FREQ = 55.0
 
 
+@pytest.fixture(autouse=True)
+def _stub_external_api():
+    """Override global HTTP stubs; no network calls here."""
+    pass
+
+
 def test_isr_shapes_and_peak():
     out = simulate_isr(params=ISRParams(steps=512, t1=5.12))
     fs = estimate_fs(out["t"])
     spec = gamma_spectrum(out["y"], idx=5, fs=fs, ts=out["t"])
     f0 = dominant_freq(spec, fs=fs)
     assert MIN_DOM_FREQ <= f0 <= MAX_DOM_FREQ
+
+
+@pytest.mark.parametrize("missing_module, err_msg", [("jax", "JAX"), ("diffrax", "Diffrax")])
+def test_simulate_isr_missing_dependencies(monkeypatch, missing_module, err_msg):
+    monkeypatch.setitem(sys.modules, missing_module, None)
+    if missing_module == "jax":
+        monkeypatch.setitem(sys.modules, "jax.numpy", None)
+    monkeypatch.delitem(sys.modules, "factsynth_ultimate.isr", raising=False)
+    monkeypatch.delitem(sys.modules, "factsynth_ultimate.isr.sim", raising=False)
+    with pytest.raises(RuntimeError, match=err_msg):
+        importlib.import_module("factsynth_ultimate.isr.sim")


### PR DESCRIPTION
## Summary
- gracefully fail ISR simulation when JAX or Diffrax are missing with helpful install hints
- test ISR module behavior when dependencies are absent

## Testing
- `pytest tests/test_isr.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5af5726248329b8491bde1d96dd37