### PR TITLE
feat: externalize i18n catalogs

### DIFF
--- a/src/factsynth_ultimate/locales/en.json
+++ b/src/factsynth_ultimate/locales/en.json
@@ -1,0 +1,8 @@
+{
+  "internal_server_error": "Internal Server Error",
+  "payload_too_large": "Payload Too Large",
+  "forbidden": "Forbidden",
+  "unauthorized": "Unauthorized",
+  "too_many_requests": "Too Many Requests",
+  "only_en": "Only EN"
+}

--- a/src/factsynth_ultimate/locales/uk.yaml
+++ b/src/factsynth_ultimate/locales/uk.yaml
@@ -1,0 +1,5 @@
+internal_server_error: "Внутрішня помилка сервера"
+payload_too_large: "Занадто великий запит"
+forbidden: "Заборонено"
+unauthorized: "Неавторизовано"
+too_many_requests: "Забагато запитів"


### PR DESCRIPTION
## Summary
- load translations from JSON/YAML locale files
- allow refreshing loaded catalogs at runtime
- update i18n tests to verify locale loading and fallback

## Testing
- `pre-commit run --files src/factsynth_ultimate/i18n.py tests/test_i18n.py src/factsynth_ultimate/locales/en.json src/factsynth_ultimate/locales/uk.yaml` *(fails: tests/test_auth.py, tests/test_source_store.py)*
- `pytest tests/test_i18n.py`

------
https://chatgpt.com/codex/tasks/task_e_68c655186afc8329a2b2dab5b83690ce