### PR TITLE
Introduce retriever protocol and plugin loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ fsu-api = "factsynth_ultimate.app:create_app"
 fsu-glrtpm = "factsynth_ultimate.glrtpm.pipeline:GLRTPMPipeline"
 fsu-isr = "factsynth_ultimate.cli_isr:app"
 
+[project.entry-points."factsynth_ultimate.retrievers"]
+fixture = "factsynth_ultimate.services.retrievers.local:create_fixture_retriever"
+
 [tool.black]
 line-length = 100
 target-version = ["py310", "py311"]

--- a/src/factsynth_ultimate/services/retrievers/__init__.py
+++ b/src/factsynth_ultimate/services/retrievers/__init__.py
@@ -1,0 +1,5 @@
+"""Retriever implementations and protocol definitions."""
+
+from .base import RetrievedDoc, Retriever
+
+__all__ = ["RetrievedDoc", "Retriever"]

--- a/src/factsynth_ultimate/services/retrievers/base.py
+++ b/src/factsynth_ultimate/services/retrievers/base.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Protocol definitions for document retrievers."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class RetrievedDoc:
+    """Result returned by a retriever search."""
+
+    id: str
+    text: str
+    score: float
+
+
+@runtime_checkable
+class Retriever(Protocol):
+    """Protocol for search backends used by :func:`evaluate_claim`."""
+
+    def search(self, query: str, k: int = 5) -> Iterable[RetrievedDoc]:
+        """Return up to ``k`` documents relevant to ``query``."""
+
+    def close(self) -> None:  # pragma: no cover - optional
+        """Release any open resources."""
+
+    async def aclose(self) -> None:  # pragma: no cover - optional
+        """Asynchronously release any open resources."""

--- a/tests/test_local_fixture_retriever.py
+++ b/tests/test_local_fixture_retriever.py
@@ -1,6 +1,6 @@
 import pytest
 
-from factsynth_ultimate.services.retriever import (
+from factsynth_ultimate.services.retrievers.local import (
     Fixture,
     LocalFixtureRetriever,
 )

--- a/tests/test_redact_pii.py
+++ b/tests/test_redact_pii.py
@@ -1,9 +1,8 @@
 import pytest
 
-from factsynth_ultimate.services.redaction import redact_pii
 from factsynth_ultimate.services.evaluator import evaluate_claim
-from factsynth_ultimate.services.retriever import RetrievedDoc
-
+from factsynth_ultimate.services.redaction import redact_pii
+from factsynth_ultimate.services.retrievers.base import RetrievedDoc
 
 pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 


### PR DESCRIPTION
## Summary
- define `Retriever` protocol and `RetrievedDoc` dataclass
- load retriever implementations via entry points in `evaluate_claim`
- migrate local fixture retriever to plugin-style module and update tests

## Testing
- `pre-commit run --files pyproject.toml src/factsynth_ultimate/services/evaluator.py src/factsynth_ultimate/services/retrievers/__init__.py src/factsynth_ultimate/services/retrievers/base.py src/factsynth_ultimate/services/retrievers/local.py tests/test_evaluator_api.py tests/test_local_fixture_retriever.py tests/test_redact_pii.py`
- `pytest tests/test_evaluator_api.py tests/test_local_fixture_retriever.py tests/test_redact_pii.py`


------
https://chatgpt.com/codex/tasks/task_e_68c65519d6a8832987de379a1a8fd118