### PR TITLE
test: ensure streams halt and cleanup on disconnect

### DIFF
--- a/tests/test_stream_sse.py
+++ b/tests/test_stream_sse.py
@@ -1,7 +1,11 @@
+import asyncio
 from http import HTTPStatus
 
 import pytest
 
+from factsynth_ultimate.api import routers
+from factsynth_ultimate.core.metrics import current_sse_tokens
+from factsynth_ultimate.schemas.requests import ScoreReq
 
 pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
@@ -36,3 +40,51 @@ async def test_sse_stream_custom_token_delay(client, base_headers, monkeypatch):
         await r.aread()
 
     assert calls and all(call == pytest.approx(0.01) for call in calls)
+
+
+@pytest.mark.anyio
+async def test_sse_stream_stops_on_disconnect(monkeypatch):
+    class DummyRequest:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def is_disconnected(self) -> bool:
+            self.calls += 1
+            return self.calls > 2  # noqa: PLR2004
+
+    class DummyRetriever:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    retr = DummyRetriever()
+
+    class DummyTokens(list):
+        def __init__(self) -> None:
+            super().__init__(["a", "b", "c"])
+            self.retriever = retr
+
+    def fake_tokenize_preview(text: str, max_tokens: int = 256) -> DummyTokens:
+        del text, max_tokens
+        return DummyTokens()
+
+    monkeypatch.setattr(routers, "tokenize_preview", fake_tokenize_preview)
+
+    initial = current_sse_tokens()
+    resp = await routers.stream(ScoreReq(text="whatever"), DummyRequest())
+    agen = resp.body_iterator
+    parts: list[str] = []
+    while True:
+        try:
+            part = await agen.__anext__()
+            parts.append(part)
+            await asyncio.sleep(0.01)
+        except StopAsyncIteration:
+            break
+
+    assert retr.closed
+    diff = current_sse_tokens() - initial
+    assert diff == 2  # noqa: PLR2004
+    assert any("event: end" in p for p in parts)

--- a/tests/test_ws_stream.py
+++ b/tests/test_ws_stream.py
@@ -1,7 +1,12 @@
+import time
+
 import pytest
 from fastapi.testclient import TestClient as SyncClient
 
+from factsynth_ultimate.api import routers
 from factsynth_ultimate.app import app
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
 
 @pytest.mark.smoke
@@ -11,3 +16,35 @@ def test_ws_stream_basic():
         ws.send_text("ping")
         msg = ws.receive_text()
         assert isinstance(msg, str) and len(msg) > 0
+
+
+def test_ws_stream_disconnect_closes_resources(monkeypatch):
+    class DummyRetriever:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    retr = DummyRetriever()
+
+    class DummyTokens(list):
+        def __init__(self) -> None:
+            super().__init__(["a", "b", "c"])
+            self.retriever = retr
+
+    def fake_tokenize_preview(text: str, max_tokens: int = 128) -> DummyTokens:
+        del text, max_tokens
+        return DummyTokens()
+
+    monkeypatch.setattr(routers, "tokenize_preview", fake_tokenize_preview)
+
+    sc = SyncClient(app)
+    with sc.websocket_connect("/ws/stream", headers={"x-api-key": "change-me"}) as ws:
+        ws.send_text("ping")
+        time.sleep(0.01)
+        msg = ws.receive_json()
+        assert msg == {"t": "a"}
+        ws.close()
+
+    assert retr.closed


### PR DESCRIPTION
## Summary
- close websocket resources and handle disconnects
- test SSE producer halts on request disconnect and tracks token metrics
- test websocket stream closes retrievers on client disconnect

## Testing
- `pre-commit run --files src/factsynth_ultimate/api/routers.py tests/test_stream_sse.py tests/test_ws_stream.py`
- `pytest tests/test_stream_sse.py tests/test_ws_stream.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6551ace3c8329ae21f6bde0171fa9