### PR TITLE
Log Vault errors

### DIFF
--- a/src/factsynth_ultimate/core/secrets.py
+++ b/src/factsynth_ultimate/core/secrets.py
@@ -55,7 +55,7 @@ def read_api_key(env: str, env_file: str, default: Optional[str], env_name: str)
             if val:
                 key = str(val)
         except VaultError as err:
-            logger.warning("Vault error: %s", err)
+            logger.warning("Vault error: %s", err, exc_info=True)
     # 3) environment
     if not key:
         val = os.getenv(env)

--- a/tests/test_core_secrets.py
+++ b/tests/test_core_secrets.py
@@ -88,4 +88,9 @@ def test_read_api_key_vault_logs_error(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         secrets.read_api_key("MISSING", "MISSING_FILE", None, "API")
 
-    assert any("Vault error" in r.message and "fail" in r.message for r in caplog.records)
+    assert any(
+        r.levelno == logging.WARNING
+        and "Vault error" in r.message
+        and "fail" in r.message
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log and include stack details on Vault secret retrieval failures
- assert warning-level Vault logging in tests

## Testing
- `pytest tests/test_core_secrets.py::test_read_api_key_vault_logs_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6589f9d648329bb2e220fd7cc04b4