### PR TITLE
Handle async retriever shutdown

### DIFF
--- a/tests/test_evaluator_api.py
+++ b/tests/test_evaluator_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import pytest
@@ -65,7 +66,8 @@ def test_evaluate_claim_handles_retriever_exception_and_closes():
     assert retriever.closed
 
 
-def test_evaluate_claim_closes_async_retriever():
+@pytest.mark.asyncio
+async def test_evaluate_claim_closes_async_retriever():
     class DummyRetriever:
         def __init__(self):
             self.closed = False
@@ -79,12 +81,14 @@ def test_evaluate_claim_closes_async_retriever():
     retriever = DummyRetriever()
 
     result = evaluate_claim("gamma", retriever=retriever)
+    await asyncio.sleep(0)
 
     assert result["evidence"] == []
     assert retriever.closed
 
 
-def test_evaluate_claim_handles_async_retriever_exception_and_closes():
+@pytest.mark.asyncio
+async def test_evaluate_claim_handles_async_retriever_exception_and_closes():
     class DummyRetriever:
         def __init__(self):
             self.closed = False
@@ -98,6 +102,7 @@ def test_evaluate_claim_handles_async_retriever_exception_and_closes():
     retriever = DummyRetriever()
 
     result = evaluate_claim("delta", retriever=retriever)
+    await asyncio.sleep(0)
 
     assert result["evidence"] == []
     assert retriever.closed


### PR DESCRIPTION
## Summary
- ensure evaluator schedules `aclose` via running loop or `asyncio.run`
- test async retrievers close correctly

## Testing
- `pytest tests/test_evaluator_api.py tests/test_redact_pii.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis'; ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68c658a11654832985abb5fe13f4c10e