### PR TITLE
Ensure newline at akpshi init and POSIX line endings

### DIFF
--- a/src/factsynth_ultimate/akpshi/__init__.py
+++ b/src/factsynth_ultimate/akpshi/__init__.py
@@ -1,1 +1,2 @@
 """AKP-SHI statistical metrics."""
+


### PR DESCRIPTION
## Summary
- Add trailing newline to `akpshi/__init__.py` for POSIX compliance
- Confirm POSIX line endings across `akpshi` module files

## Testing
- `pytest tests/test_akpshi.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c658a6e9f0832993c8d3bdd05f8bf6