### PR TITLE
test: ensure streaming body limit respected

### DIFF
--- a/tests/test_body_limit_streaming.py
+++ b/tests/test_body_limit_streaming.py
@@ -1,0 +1,70 @@
+from http import HTTPStatus
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from factsynth_ultimate.core.body_limit import BodySizeLimitMiddleware
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+MAX_BYTES = 1024
+CHUNK = b"x" * 512
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware, max_bytes=MAX_BYTES)
+
+    @app.post("/")
+    async def root(request: Request):
+        data = await request.body()
+        return {"received": len(data)}
+
+    return app
+
+
+@pytest.mark.anyio
+async def test_streaming_request_exceeds_limit() -> None:
+    app = create_app()
+    calls = 0
+    sent = 0
+    total_chunks = 5  # total 2560 bytes
+
+    async def gen():
+        nonlocal calls, sent
+        for _ in range(total_chunks):
+            calls += 1
+            sent += len(CHUNK)
+            yield CHUNK
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/", content=gen())
+
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert calls < total_chunks  # server stopped reading early
+    assert sent <= MAX_BYTES + len(CHUNK)
+
+
+@pytest.mark.anyio
+async def test_streaming_request_at_limit_ok() -> None:
+    app = create_app()
+    calls = 0
+    sent = 0
+    total_chunks = 2  # total 1024 bytes equals limit
+
+    async def gen():
+        nonlocal calls, sent
+        for _ in range(total_chunks):
+            calls += 1
+            sent += len(CHUNK)
+            yield CHUNK
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/", content=gen())
+
+    assert resp.status_code == HTTPStatus.OK
+    assert calls == total_chunks
+    assert sent == MAX_BYTES


### PR DESCRIPTION
## Summary
- add streaming body limit tests with async generators
- cover boundary case at max_bytes

## Testing
- `pytest tests/test_body_limit_streaming.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c65a96be508329b9e4d2ce703fc4cc