### PR TITLE
Enforce coverage threshold in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,4 @@ omit =
 [report]
 exclude_lines =
     pragma: no cover
+fail_under = 85

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,8 @@ jobs:
       - name: Unit tests (Python)
         if: hashFiles('tests/**','pyproject.toml','requirements.txt') != ''
         run: |
-          pip install pytest
-          pytest -q
+          pip install pytest pytest-cov
+          pytest
 
       - name: Fairness tests
         if: hashFiles('fairness_tests/**','pyproject.toml','requirements.txt') != ''

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -q -ra
+addopts = -q -ra --cov --cov-report=term-missing
 testpaths = tests
 pythonpath = src
 filterwarnings = ignore::DeprecationWarning


### PR DESCRIPTION
## Summary
- require 85% coverage in `.coveragerc`
- run pytest with coverage by default
- ensure CI installs pytest-cov and runs coverage checks

## Testing
- `pytest` *(fails: Required test coverage of 85.0% not reached. Total coverage: 81.06%)*

------
https://chatgpt.com/codex/tasks/task_e_68c65a998a64832988ea89cea1f3e02c