### PR TITLE
Add mutmut mutation testing setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,16 @@ test:
 	. .venv/bin/activate && pytest
 
 lint:
-	. .venv/bin/activate && ruff check . && mypy src
+        . .venv/bin/activate && ruff check . && mypy src
 
 api:
-	. .venv/bin/activate && fsu-api
+        . .venv/bin/activate && fsu-api
 
 docker:
-	docker build -t factsynth-ultimate:2.0 . && docker run --rm -p 8000:8000 -e API_KEY=change-me factsynth-ultimate:2.0
+        docker build -t factsynth-ultimate:2.0 . && docker run --rm -p 8000:8000 -e API_KEY=change-me factsynth-ultimate:2.0
+
+mutmut:
+        . .venv/bin/activate && mutmut run
 
 # Added by Incubation Pack
 .PHONY: release sbom checksums test-contract

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -41,3 +41,11 @@
 > ```bash
 > pip install -e .[numpy]
 > ```
+
+## Мутаційне тестування
+
+Запусти мутаційні тести для основних модулів (`src/factsynth_ultimate/core`, `src/factsynth_ultimate/services`, `src/factsynth_ultimate/api`):
+
+```bash
+mutmut run  # або make mutmut
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pre-commit==4.3.0",  # Git hooks runner
     "pytest-httpx==0.35.0",  # HTTPX mocking for tests
     "pip-tools==7.5.0",  # requirements management
+    "mutmut==3.2.0",  # mutation testing
 ]
 ops = [
     "prometheus-client==0.22.1",

--- a/tests/mutmut.ini
+++ b/tests/mutmut.ini
@@ -1,0 +1,3 @@
+[mutmut]
+paths_to_mutate = src/factsynth_ultimate/core src/factsynth_ultimate/services src/factsynth_ultimate/api
+tests_dir = tests


### PR DESCRIPTION
## Summary
- add mutmut as a development optional dependency
- configure Makefile target to run mutmut
- document and configure mutation testing via `tests/mutmut.ini`

## Testing
- `SKIP=pip-compile pre-commit run --files pyproject.toml tests/mutmut.ini Makefile README_TESTING.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68c65a9ab7d48329be346eae32069f12