### PR TITLE
Enforce coverage threshold and run coverage in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,4 @@ omit =
 [report]
 exclude_lines =
     pragma: no cover
+fail_under = 85

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,8 @@ jobs:
       - name: Unit tests (Python)
         if: hashFiles('tests/**','pyproject.toml','requirements.txt') != ''
         run: |
-          pip install pytest
-          pytest -q
+          pip install pytest pytest-cov
+          pytest --cov --cov-report=term-missing
 
       - name: Fairness tests
         if: hashFiles('fairness_tests/**','pyproject.toml','requirements.txt') != ''

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -q -ra
+addopts = -q -ra --cov --cov-report=term-missing
 testpaths = tests
 pythonpath = src
 filterwarnings = ignore::DeprecationWarning


### PR DESCRIPTION
## Summary
- enforce 85% coverage threshold via `.coveragerc`
- include coverage reporting in `pytest.ini`
- run unit tests with coverage in CI workflow

## Testing
- `pre-commit run --files .coveragerc pytest.ini .github/workflows/ci.yml`
- `pytest tests/test_settings_validation.py::test_csv_fields --maxfail=1 -q` *(fails: fixture 'httpx_mock' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67e761dfc832981681cbab3a1a978