### PR TITLE
Add websocket disconnect handling and tests

### DIFF
--- a/tests/test_ws_stream.py
+++ b/tests/test_ws_stream.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient as SyncClient
 
 from factsynth_ultimate.api import routers
 from factsynth_ultimate.app import app
+from factsynth_ultimate.core.metrics import current_sse_tokens
 
 pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
@@ -16,6 +17,16 @@ def test_ws_stream_basic():
         ws.send_text("ping")
         msg = ws.receive_text()
         assert isinstance(msg, str) and len(msg) > 0
+
+
+def test_ws_stream_slow_reader():
+    sc = SyncClient(app)
+    with sc.websocket_connect("/ws/stream", headers={"x-api-key": "change-me"}) as ws:
+        ws.send_text("alpha beta gamma")
+        for tok in ("alpha", "beta", "gamma"):
+            time.sleep(0.01)
+            assert ws.receive_json() == {"t": tok}
+        assert ws.receive_json() == {"end": True}
 
 
 def test_ws_stream_disconnect_closes_resources(monkeypatch):
@@ -39,12 +50,23 @@ def test_ws_stream_disconnect_closes_resources(monkeypatch):
 
     monkeypatch.setattr(routers, "tokenize_preview", fake_tokenize_preview)
 
+    calls = 0
+
+    def fake_is_client_connected(_ws):
+        nonlocal calls
+        calls += 1
+        return False
+
+    monkeypatch.setattr(routers, "is_client_connected", fake_is_client_connected)
+
     sc = SyncClient(app)
+    initial = current_sse_tokens()
     with sc.websocket_connect("/ws/stream", headers={"x-api-key": "change-me"}) as ws:
         ws.send_text("ping")
-        time.sleep(0.01)
-        msg = ws.receive_json()
-        assert msg == {"t": "a"}
         ws.close()
+        time.sleep(0.05)
 
+    diff = current_sse_tokens() - initial
     assert retr.closed
+    assert diff == 0
+    assert calls >= 1


### PR DESCRIPTION
## Summary
- add client connection check and token metric tracking to websocket stream
- cover websocket slow-read and disconnect scenarios

## Testing
- `ruff check tests/test_ws_stream.py src/factsynth_ultimate/api/routers.py`
- `pytest tests/test_ws_stream.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67e77753c83299a87639cdcba03d0