### PR TITLE
test: enforce retriever contract

### DIFF
--- a/src/factsynth_ultimate/services/evaluator.py
+++ b/src/factsynth_ultimate/services/evaluator.py
@@ -34,7 +34,7 @@ def _load_retriever(name: str) -> Retriever:
     raise LookupError(f"Retriever '{name}' not found")
 
 
-def evaluate_claim(  # noqa: PLR0913,C901
+def evaluate_claim(  # noqa: PLR0913,C901,PLR0912
     claim: str,
     *,
     policy_check: Callable[[str], Any] | None = None,
@@ -63,6 +63,14 @@ def evaluate_claim(  # noqa: PLR0913,C901
     out: ResultDict = {}
     if isinstance(retriever, str):
         retriever = _load_retriever(retriever)
+    if retriever is not None:
+        if not callable(getattr(retriever, "search", None)):
+            raise TypeError("retriever must implement search()")
+        if not (
+            callable(getattr(retriever, "close", None))
+            or callable(getattr(retriever, "aclose", None))
+        ):
+            raise TypeError("retriever must implement close() or aclose()")
     with ExitStack() as stack:
         if retriever:
             aclose = getattr(retriever, "aclose", None)

--- a/tests/test_retriever_contract.py
+++ b/tests/test_retriever_contract.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+
+from factsynth_ultimate.services.evaluator import evaluate_claim
+from factsynth_ultimate.services.retrievers.base import RetrievedDoc
+
+pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+
+
+def test_evaluate_claim_closes_sync_retriever():
+    class DummyRetriever:
+        def __init__(self):
+            self.closed = False
+
+        def search(self, _query):
+            return [RetrievedDoc(id="1", text="t", score=1.0)]
+
+        def close(self):
+            self.closed = True
+
+    retriever = DummyRetriever()
+
+    evaluate_claim("alpha", retriever=retriever)
+
+    assert retriever.closed
+
+
+@pytest.mark.asyncio
+async def test_evaluate_claim_closes_async_retriever():
+    class DummyRetriever:
+        def __init__(self):
+            self.closed = False
+
+        def search(self, _query):
+            return []
+
+        async def aclose(self):
+            self.closed = True
+
+    retriever = DummyRetriever()
+
+    evaluate_claim("beta", retriever=retriever)
+    await asyncio.sleep(0)
+
+    assert retriever.closed
+
+
+def test_evaluate_claim_rejects_missing_search():
+    class BadRetriever:
+        def close(self):  # pragma: no cover - no-op
+            pass
+
+    with pytest.raises(TypeError):
+        evaluate_claim("gamma", retriever=BadRetriever())
+
+
+def test_evaluate_claim_rejects_noncallable_search():
+    class BadRetriever:
+        search = None
+
+    with pytest.raises(TypeError):
+        evaluate_claim("delta", retriever=BadRetriever())


### PR DESCRIPTION
## Summary
- enforce retriever interface validation in `evaluate_claim`
- add retriever contract tests for sync and async cleanup and invalid implementations

## Testing
- `ruff check src/factsynth_ultimate/services/evaluator.py tests/test_retriever_contract.py`
- `pytest tests/test_retriever_contract.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67e787b388329b89f2297764f6c51