### PR TITLE
chore: pin GitHub Actions and add updater script

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,10 +9,10 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with: { node-version: 'lts/*', cache: 'npm' }
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with: { python-version: '3.11', cache: 'pip' }
       - name: Install deps
         run: |
@@ -26,6 +26,6 @@ jobs:
           mkdir -p dist
           git archive -o dist/factsynth-${{ github.ref_name }}.zip --format zip HEAD
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
         with: { files: dist/*.zip }
         env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
       RATE_LIMIT_PER_IP: "1000"
       RATE_LIMIT_PER_ORG: "1000"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with: { fetch-depth: 0 }
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 'lts/*'
           cache: 'npm'
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ci-failures-${{ matrix.python-version }}
           if-no-files-found: ignore
@@ -155,8 +155,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/build-push-action@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           load: true
@@ -167,6 +167,6 @@ jobs:
           format: sarif
           output: trivy.sarif
           severity: HIGH,CRITICAL
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@528ca598d956c91826bd742262cdfc5d02b77710
         with:
           sarif_file: trivy.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         language: [ javascript, python ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: github/codeql-action/init@528ca598d956c91826bd742262cdfc5d02b77710
         with: { languages: ${{ matrix.language }} }
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@528ca598d956c91826bd742262cdfc5d02b77710

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -17,16 +17,16 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -34,7 +34,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=sha
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           push: true

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -14,8 +14,8 @@ jobs:
   trivy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/build-push-action@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           load: true
@@ -26,5 +26,5 @@ jobs:
           format: sarif
           output: trivy.sarif
           severity: HIGH,CRITICAL
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@528ca598d956c91826bd742262cdfc5d02b77710
         with: { sarif_file: trivy.sarif }

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -6,8 +6,8 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with: { python-version: '3.11', cache: 'pip' }
       - name: Install docs dependencies
         run: |

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -19,8 +19,8 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: davidanson/markdownlint-cli2-action@v17
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: davidanson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809
         with:
           globs: |
             README.md

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,12 +19,12 @@ jobs:
     env:
       STRICT_FAIL_FATAL: ${{ vars.STRICT_FAIL_FATAL || 'false' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: "20"
           cache: "npm"
@@ -48,7 +48,7 @@ jobs:
           fi
       - name: Upload strict build log
         if: steps.mkdocs.outputs.strict_failed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: strict-log
           path: strict.log
@@ -60,8 +60,8 @@ jobs:
           else
             echo "<!doctype html><title>No OpenAPI</title><p>No openapi/openapi.yaml</p>" > site/openapi/index.html
           fi
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:
           path: site
 
@@ -73,4 +73,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -9,9 +9,9 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@2fe545c4960e5d3ae6e60585a73c291287653aab
         with:
           reporter: github-pr-check
           level: error

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint api docker
+.PHONY: install test lint api docker update-actions
 
 install:
 	python -m venv .venv && . .venv/bin/activate && pip install -U pip && pip install --require-hashes -r requirements.lock && pip install -e .[dev,ops]
@@ -13,7 +13,10 @@ api:
 	. .venv/bin/activate && fsu-api
 
 docker:
-	docker build -t factsynth-ultimate:2.0 . && docker run --rm -p 8000:8000 -e API_KEY=change-me factsynth-ultimate:2.0
+        docker build -t factsynth-ultimate:2.0 . && docker run --rm -p 8000:8000 -e API_KEY=change-me factsynth-ultimate:2.0
+
+update-actions:
+        scripts/update-actions.sh
 
 # Added by Incubation Pack
 .PHONY: release sbom checksums test-contract

--- a/README_CI.md
+++ b/README_CI.md
@@ -34,6 +34,17 @@ npx markdownlint-cli2 README.md .github/PULL_REQUEST_TEMPLATE.md
 
     Отримаєш артефакти (wheel+sdist+checksums+SBOM) і контейнер у GHCR.
 
+## Updating GitHub Action pins
+
+Щоб оновити закріплені версії GitHub Action до останніх комітів
+відповідних мажорних тегів, запусти:
+
+```bash
+scripts/update-actions.sh
+```
+
+Перевір зміни в `.github/workflows` і закоміть оновлені файли.
+
 ## Cleanup branches with failed checks
 
 Use the **Cleanup branches with failed checks** workflow to prune branches whose

--- a/scripts/update-actions.sh
+++ b/scripts/update-actions.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update pinned GitHub Actions SHAs in workflow files.
+# For each uses: owner/repo@<sha>, determine the major tag and
+# update to the latest commit for that tag.
+
+WORKFLOW_DIR=".github/workflows"
+
+find "$WORKFLOW_DIR" -name '*.yml' -o -name '*.yaml' | while read -r file; do
+  tmp="$file.tmp"
+  cp "$file" "$tmp"
+  while read -r line; do
+    if [[ $line =~ uses:\ ([^@]+)@([0-9a-f]{40}) ]]; then
+      action="${BASH_REMATCH[1]}"
+      sha="${BASH_REMATCH[2]}"
+      repo="https://github.com/$action"
+      tag=$(git ls-remote "$repo" | grep "$sha" | awk '/refs\/tags\/v/{print $2}' | head -n1 || true)
+      if [[ -z "$tag" ]]; then
+        continue
+      fi
+      major=$(echo "$tag" | sed -E 's|refs/tags/(v[0-9]+).*|\1|')
+      latest=$(git ls-remote "$repo" "refs/tags/$major" | awk '{print $1}')
+      if [[ -n "$latest" && "$latest" != "$sha" ]]; then
+        echo "$file: Updating $action from $sha to $latest ($major)"
+        sed -i "s|$action@$sha|$action@$latest|" "$file"
+      fi
+    fi
+  done < "$tmp"
+  rm "$tmp"
+
+done


### PR DESCRIPTION
## Summary
- pin all GitHub Actions to immutable commit SHAs
- add `scripts/update-actions.sh` and Makefile target for refreshing SHAs
- document how to update pinned GitHub Actions

## Testing
- `pre-commit run --files .github/workflows/ci-release.yml .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/container-release.yml .github/workflows/container-scan.yml .github/workflows/docs-build.yml .github/workflows/docs-quality.yml .github/workflows/pages.yml .github/workflows/workflows-lint.yml Makefile README_CI.md scripts/update-actions.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c683f0ecf8832997ae67e37d9ffae6