### PR TITLE
ci: add job timeouts and mkdocs smoke check

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -5,6 +5,7 @@ permissions: { contents: read }
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       STRICT_FAIL_FATAL: ${{ vars.STRICT_FAIL_FATAL || 'false' }}
     steps:
@@ -46,6 +47,13 @@ jobs:
               exit "$strict_exit"
             fi
           fi
+      - name: Smoke test MkDocs serve
+        run: |
+          timeout 15s mkdocs serve --watch >/tmp/mkdocs-serve.log 2>&1 || exit_code=$?
+          if [ "${exit_code:-0}" != "124" ]; then
+            cat /tmp/mkdocs-serve.log
+            exit "${exit_code:-1}"
+          fi
       - name: Upload strict build log
         if: steps.mkdocs.outputs.strict_failed == 'true'
         uses: actions/upload-artifact@v4
@@ -68,6 +76,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README_CI.md
+++ b/README_CI.md
@@ -34,6 +34,11 @@ npx markdownlint-cli2 README.md .github/PULL_REQUEST_TEMPLATE.md
 
     Отримаєш артефакти (wheel+sdist+checksums+SBOM) і контейнер у GHCR.
 
+## CI limits
+
+Документаційні пайплайни (`docs-build.yml`, `pages.yml`) мають обмеження `timeout-minutes: 20`,
+щоб запобігти зависанням і пришвидшити фідбек. Коригуй за потреби.
+
 ## Cleanup branches with failed checks
 
 Use the **Cleanup branches with failed checks** workflow to prune branches whose


### PR DESCRIPTION
## Summary
- add 20-minute timeouts to docs-build and pages workflows
- smoke-test mkdocs `serve --watch` before deploying pages
- document new CI timeout limits

## Testing
- `pre-commit run --files .github/workflows/docs-build.yml .github/workflows/pages.yml README_CI.md`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: The following responses are mocked but not requested)*

------
https://chatgpt.com/codex/tasks/task_e_68c683f5082c832996127d20a4c633d2