### PR TITLE
chore: harden container scan

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,7 +9,7 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: actions/setup-node@v5
         with: { node-version: 'lts/*', cache: 'npm' }
       - uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       RATE_LIMIT_PER_IP: "1000"
       RATE_LIMIT_PER_ORG: "1000"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with: { fetch-depth: 0 }
 
       - uses: actions/setup-node@v5
@@ -155,18 +155,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-test
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/build-push-action@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           load: true
           tags: factsynth:ci
-      - uses: aquasecurity/trivy-action@0.33.1
+      - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: factsynth:ci
           format: sarif
           output: trivy.sarif
           severity: HIGH,CRITICAL
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3
         with:
           sarif_file: trivy.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         language: [ javascript, python ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: github/codeql-action/init@v3
         with: { languages: ${{ matrix.language }} }
       - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -34,7 +34,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=sha
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           push: true

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -13,18 +13,25 @@ permissions:
 jobs:
   trivy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency: { group: container-scan-${{ github.ref }}, cancel-in-progress: true }
+    env: { TRIVY_CACHE_DIR: trivy-cache }
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/build-push-action@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: trivy-cache
+          key: trivy-${{ runner.os }}-${{ hashFiles('Dockerfile') }}
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           load: true
           tags: factsynth:ci
-      - uses: aquasecurity/trivy-action@0.33.1
+      - uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
         with:
           image-ref: factsynth:ci
           format: sarif
           output: trivy.sarif
           severity: HIGH,CRITICAL
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3
         with: { sarif_file: trivy.sarif }

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -6,7 +6,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: actions/setup-python@v6
         with: { python-version: '3.11', cache: 'pip' }
       - name: Install docs dependencies

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -19,7 +19,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: davidanson/markdownlint-cli2-action@v17
         with:
           globs: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       STRICT_FAIL_FATAL: ${{ vars.STRICT_FAIL_FATAL || 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -9,7 +9,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run actionlint
         uses: reviewdog/action-actionlint@v1
         with:


### PR DESCRIPTION
## Summary
- pin GitHub Actions to immutable SHAs
- add timeout, concurrency and cache to container scan

## Testing
- `pre-commit run --files .github/workflows/container-scan.yml .github/workflows/ci.yml .github/workflows/container-release.yml .github/workflows/ci-release.yml .github/workflows/docs-quality.yml .github/workflows/docs-build.yml .github/workflows/pages.yml .github/workflows/codeql.yml .github/workflows/workflows-lint.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c687154e608329846ceccfe48b421e