### PR TITLE
Add dependency review workflow and document security policies

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,12 @@
+# Security Policy
+
 Report vulnerabilities to <https://github.com/neuron7x/FactSynth/security/advisories/new>.
 Avoid public issues for sensitive findings.
+
+## Secret scanning
+
+GitHub's secret scanning and push protection are enabled to block commits that contain credentials or other tokens. Repository administrators should keep these protections active.
+
+## Dependency review
+
+Pull requests run a dependency review that fails when new dependencies contain known vulnerabilities of high severity. The main branch is protected and requires the "Dependency Review" check to pass before merging.


### PR DESCRIPTION
## Summary
- document secret scanning, push protection, and dependency review in `SECURITY.md`
- add GitHub Actions workflow to fail PRs with high-severity dependency vulnerabilities

## Testing
- `pre-commit run --files SECURITY.md .github/workflows/dependency-review.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c68718b86c83299c7386140bf276fa