### PR TITLE
chore: add dependency baseline audit

### DIFF
--- a/.github/workflows/dependency-baseline.yml
+++ b/.github/workflows/dependency-baseline.yml
@@ -1,0 +1,77 @@
+name: Dependency Baseline
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements.lock
+            pyproject.toml
+
+      - name: Install JS deps
+        if: hashFiles('package.json') != ''
+        run: |
+          if [ -f pnpm-lock.yaml ]; then npm i -g pnpm && pnpm i --frozen-lockfile;
+          elif [ -f yarn.lock ]; then corepack enable && yarn install --immutable;
+          elif [ -f package-lock.json ]; then npm ci;
+          else echo "No JS lockfile, skipping strict install"; fi
+
+      - name: Install Python deps
+        if: hashFiles('requirements.txt','requirements.lock','pyproject.toml') != ''
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.lock ]; then
+            pip install -r requirements.lock
+          elif [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+          [ -f pyproject.toml ] && pip install . || true
+
+      - name: pip-audit
+        if: hashFiles('requirements.txt','requirements.lock','pyproject.toml') != ''
+        run: |
+          pip install pip-audit
+          pip-audit -f sarif -o pip-audit.sarif || true
+        continue-on-error: true
+
+      - name: npm audit
+        if: hashFiles('package-lock.json') != ''
+        run: |
+          npm audit --json > npm-audit.json || true
+          npx --yes npm-audit-sarif --input npm-audit.json --output npm-audit.sarif || true
+        continue-on-error: true
+
+      - name: Upload pip-audit SARIF
+        if: hashFiles('requirements.txt','requirements.lock','pyproject.toml') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: pip-audit.sarif
+
+      - name: Upload npm audit SARIF
+        if: hashFiles('package-lock.json') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: npm-audit.sarif
+


### PR DESCRIPTION
## Summary
- add scheduled workflow to run pip-audit and npm audit weekly
- upload audit results as SARIF for security tab tracking

## Testing
- `pre-commit run --files .github/workflows/dependency-baseline.yml`
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68c687199f9083298a46dbef6aeb14aa