### PR TITLE
chore(ci): pin GitHub Actions to commits

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with: { node-version: 'lts/*', cache: 'npm' }
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with: { python-version: '3.11', cache: 'pip' }
       - name: Install deps
         run: |
@@ -26,6 +26,6 @@ jobs:
           mkdir -p dist
           git archive -o dist/factsynth-${{ github.ref_name }}.zip --format zip HEAD
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
         with: { files: dist/*.zip }
         env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with: { fetch-depth: 0 }
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 'lts/*'
           cache: 'npm'
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ci-failures-${{ matrix.python-version }}
           if-no-files-found: ignore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,6 @@ jobs:
         language: [ javascript, python ]
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@528ca598d956c91826bd742262cdfc5d02b77710
         with: { languages: ${{ matrix.language }} }
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@528ca598d956c91826bd742262cdfc5d02b77710

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -23,15 +23,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/dependency-baseline.yml
+++ b/.github/workflows/dependency-baseline.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 'lts/*'
           cache: 'npm'
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -65,13 +65,13 @@ jobs:
 
       - name: Upload pip-audit SARIF
         if: hashFiles('requirements.txt','requirements.lock','pyproject.toml') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@528ca598d956c91826bd742262cdfc5d02b77710
         with:
           sarif_file: pip-audit.sarif
 
       - name: Upload npm audit SARIF
         if: hashFiles('package-lock.json') != ''
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@528ca598d956c91826bd742262cdfc5d02b77710
         with:
           sarif_file: npm-audit.sarif
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with: { python-version: '3.11', cache: 'pip' }
       - name: Install docs dependencies
         run: |

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: davidanson/markdownlint-cli2-action@v17
+      - uses: davidanson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809
         with:
           globs: |
             README.md

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,11 +21,11 @@ jobs:
       STRICT_FAIL_FATAL: ${{ vars.STRICT_FAIL_FATAL || 'false' }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: "pip"
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: "20"
           cache: "npm"
@@ -56,7 +56,7 @@ jobs:
           fi
       - name: Upload strict build log
         if: steps.mkdocs.outputs.strict_failed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: strict-log
           path: strict.log
@@ -68,8 +68,8 @@ jobs:
           else
             echo "<!doctype html><title>No OpenAPI</title><p>No openapi/openapi.yaml</p>" > site/openapi/index.html
           fi
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:
           path: site
 
@@ -82,4 +82,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@2fe545c4960e5d3ae6e60585a73c291287653aab
         with:
           reporter: github-pr-check
           level: error


### PR DESCRIPTION
## Summary
- pin GitHub Actions in workflows to specific commit SHAs for reproducibility

## Testing
- `pre-commit run --files .github/workflows/ci-release.yml .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/container-release.yml .github/workflows/dependency-baseline.yml .github/workflows/docs-build.yml .github/workflows/docs-quality.yml .github/workflows/pages.yml .github/workflows/workflows-lint.yml`
- `pytest tests/test_settings_validation.py::test_split_csv_edge_cases[-expected0] -q` *(fails: Coverage failure: total of 30 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68c6af602944832995d8dd6d0bd78f75