### PR TITLE
ci: run pre-commit in pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
           fi
           [ -f pyproject.toml ] && pip install -e .[dev] || true
 
+      - name: Pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure
+
       - name: Check lockfile
         if: hashFiles('requirements.lock','pyproject.toml') != ''
         run: |


### PR DESCRIPTION
## Summary
- run pre-commit in CI before other linters

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `./actionlint -shellcheck="" .github/workflows/ci.yml` *(fails: could not parse as YAML)*

------
https://chatgpt.com/codex/tasks/task_e_68c6af614b588329988a0132350f853f