### PR TITLE
ci: enforce pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
           fi
           [ -f pyproject.toml ] && pip install -e .[dev] || true
 
+      - name: Pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure
+
       - name: Check lockfile
         if: hashFiles('requirements.lock','pyproject.toml') != ''
         run: |


### PR DESCRIPTION
## Summary
- run pre-commit checks in CI after installing Python deps

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c6b2e93db08329bc18678df3050c8d