### PR TITLE
ci: rely on default GITHUB_TOKEN in release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -28,4 +28,3 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with: { files: dist/*.zip }
-        env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }


### PR DESCRIPTION
## Summary
- rely on default `GITHUB_TOKEN` in release workflow

## Testing
- `pre-commit run --files .github/workflows/ci-release.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c6b2ed99c08329b074bf767640c9c8