### PR TITLE
ci(docs): build docs only on docs changes

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,6 +1,10 @@
 name: Docs Build
 on:
-  pull_request: { branches: [ main ] }
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
 permissions: { contents: read }
 jobs:
   build-docs:


### PR DESCRIPTION
## Summary
- run docs build workflow only when docs or mkdocs.yml change

## Testing
- `pre-commit run --files .github/workflows/docs-build.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68c6b2edbcd0832981697160a35a0575