### PR TITLE
Add fact pipeline and integrate with generate endpoint

### DIFF
--- a/src/facts/__init__.py
+++ b/src/facts/__init__.py
@@ -1,0 +1,19 @@
+"""High-level orchestration primitives for fact synthesis."""
+
+from .pipeline import (
+    FactPipeline,
+    FactPipelineError,
+    EmptyQueryError,
+    NoFactsFoundError,
+    AggregationError,
+    SearchError,
+)
+
+__all__ = [
+    "FactPipeline",
+    "FactPipelineError",
+    "EmptyQueryError",
+    "NoFactsFoundError",
+    "AggregationError",
+    "SearchError",
+]

--- a/src/facts/pipeline.py
+++ b/src/facts/pipeline.py
@@ -1,0 +1,154 @@
+"""Composable pipeline executing the fact synthesis flow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+from factsynth_ultimate.formatting import ensure_period, sanitize
+from factsynth_ultimate.services.retrievers.base import RetrievedDoc, Retriever
+from factsynth_ultimate.services.retrievers.local import create_fixture_retriever
+
+
+class FactPipelineError(RuntimeError):
+    """Base class for errors raised during fact synthesis."""
+
+
+class EmptyQueryError(FactPipelineError):
+    """Raised when the incoming query is blank."""
+
+
+class SearchError(FactPipelineError):
+    """Raised when the retriever fails to execute."""
+
+
+class NoFactsFoundError(SearchError):
+    """Raised when the retriever returns no usable documents."""
+
+
+class AggregationError(FactPipelineError):
+    """Raised when the aggregation or formatting step fails."""
+
+
+Ranker = Callable[[Iterable[RetrievedDoc], int], Sequence[RetrievedDoc]]
+Aggregator = Callable[[Sequence[RetrievedDoc]], str]
+Formatter = Callable[[str], str]
+
+
+def default_ranker(results: Iterable[RetrievedDoc], limit: int) -> list[RetrievedDoc]:
+    """Return the top ``limit`` results sorted by score."""
+
+    ranked = sorted(results, key=lambda doc: doc.score, reverse=True)
+    seen: set[str] = set()
+    unique: list[RetrievedDoc] = []
+    for doc in ranked:
+        if doc.id in seen:
+            continue
+        unique.append(doc)
+        seen.add(doc.id)
+        if len(unique) >= max(1, limit):
+            break
+    return unique
+
+
+def default_aggregator(docs: Sequence[RetrievedDoc]) -> str:
+    """Combine supporting documents into a single paragraph."""
+
+    fragments: list[str] = []
+    for doc in docs:
+        text = doc.text.strip()
+        if not text:
+            continue
+        if text[-1] not in ".!?…":
+            text = f"{text}."
+        fragments.append(text)
+    if not fragments:
+        raise AggregationError("No supporting text to aggregate")
+    return " ".join(fragments)
+
+
+def default_formatter(text: str) -> str:
+    """Normalize aggregated text and ensure it ends with a period."""
+
+    cleaned = sanitize(
+        text,
+        forbid_questions=False,
+        forbid_headings=True,
+        forbid_lists=True,
+        forbid_emojis=True,
+    ).strip()
+    if not cleaned:
+        raise AggregationError("Formatted text is empty")
+    return ensure_period(cleaned)
+
+
+@dataclass
+class FactPipeline:
+    """Execute retrieval, ranking, aggregation and formatting for ``query``."""
+
+    retriever: Retriever | None = None
+    top_k: int = 3
+    ranker: Ranker = default_ranker
+    aggregator: Aggregator = default_aggregator
+    formatter: Formatter = default_formatter
+
+    def __post_init__(self) -> None:
+        if self.retriever is None:
+            self.retriever = create_fixture_retriever()
+        if self.top_k <= 0:
+            raise ValueError("top_k must be positive")
+
+    def run(self, query: str) -> str:
+        """Execute the pipeline and return formatted supporting facts."""
+
+        prepared = query.strip()
+        if not prepared:
+            raise EmptyQueryError("Query must not be empty")
+
+        try:
+            results = list(self.retriever.search(prepared, k=max(1, self.top_k)))
+        except FactPipelineError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            raise SearchError("Search backend failed") from exc
+
+        if not results:
+            raise NoFactsFoundError(f"No facts found for '{prepared}'")
+
+        ranked = list(self.ranker(results, self.top_k))
+        if not ranked:
+            raise NoFactsFoundError(f"No facts found for '{prepared}'")
+
+        try:
+            aggregated = self.aggregator(ranked)
+        except FactPipelineError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            raise AggregationError("Failed to aggregate supporting facts") from exc
+
+        if not aggregated.strip():
+            raise AggregationError("Aggregation produced empty output")
+
+        try:
+            formatted = self.formatter(aggregated)
+        except FactPipelineError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            raise AggregationError("Failed to format aggregated facts") from exc
+
+        if not formatted.strip():
+            raise AggregationError("Formatted output is empty")
+
+        return formatted
+
+
+__all__ = [
+    "Aggregator",
+    "FactPipeline",
+    "FactPipelineError",
+    "EmptyQueryError",
+    "NoFactsFoundError",
+    "AggregationError",
+    "Ranker",
+    "SearchError",
+]

--- a/src/factsynth_ultimate/api/v1/__init__.py
+++ b/src/factsynth_ultimate/api/v1/__init__.py
@@ -1,0 +1,5 @@
+"""Versioned API routers."""
+
+from .generate import router as generate_router
+
+__all__ = ["generate_router"]

--- a/src/factsynth_ultimate/api/v1/generate.py
+++ b/src/factsynth_ultimate/api/v1/generate.py
@@ -1,0 +1,106 @@
+"""Fact generation endpoint wired with the :class:`FactPipeline`."""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from facts import (
+    AggregationError,
+    EmptyQueryError,
+    FactPipeline,
+    FactPipelineError,
+    NoFactsFoundError,
+    SearchError,
+)
+from factsynth_ultimate.core.audit import audit_event
+from factsynth_ultimate.schemas.requests import GenerateReq
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ProblemDetails(BaseModel):
+    """Representation of an RFC 9457 problem response."""
+
+    title: str
+    detail: str
+    status: int
+    type: str = "about:blank"
+    instance: str | None = None
+
+    def to_response(self) -> JSONResponse:
+        """Return a :class:`JSONResponse` configured for problem+json."""
+
+        return JSONResponse(
+            self.model_dump(exclude_none=True),
+            status_code=self.status,
+            media_type="application/problem+json",
+        )
+
+
+def _client_host(request: Request) -> str:
+    """Best-effort retrieval of the requesting client's host."""
+
+    return getattr(getattr(request, "client", None), "host", "unknown")
+
+
+@lru_cache(maxsize=1)
+def _pipeline_singleton() -> FactPipeline:
+    """Return a singleton :class:`FactPipeline` instance."""
+
+    return FactPipeline()
+
+
+def get_fact_pipeline() -> FactPipeline:
+    """FastAPI dependency returning the shared :class:`FactPipeline`."""
+
+    return _pipeline_singleton()
+
+
+def _problem(status: HTTPStatus, title: str, detail: str) -> ProblemDetails:
+    return ProblemDetails(title=title, detail=detail, status=int(status))
+
+
+@router.post("/v1/generate")
+def generate(
+    req: GenerateReq,
+    request: Request,
+    pipeline: FactPipeline = Depends(get_fact_pipeline),
+) -> dict[str, dict[str, str]]:
+    """Produce fact statements for ``req.text`` using the orchestrated pipeline."""
+
+    audit_event("generate", _client_host(request))
+    try:
+        text = pipeline.run(req.text)
+    except EmptyQueryError as exc:
+        return _problem(HTTPStatus.BAD_REQUEST, "Invalid query", str(exc)).to_response()
+    except NoFactsFoundError as exc:
+        return _problem(HTTPStatus.NOT_FOUND, "Facts not found", str(exc)).to_response()
+    except SearchError as exc:
+        logger.warning("Fact search failed: %s", exc)
+        return _problem(HTTPStatus.BAD_GATEWAY, "Search failure", str(exc)).to_response()
+    except AggregationError as exc:
+        logger.warning("Fact aggregation failed: %s", exc)
+        return _problem(HTTPStatus.INTERNAL_SERVER_ERROR, "Aggregation failure", str(exc)).to_response()
+    except FactPipelineError as exc:
+        logger.warning("Fact pipeline error: %s", exc)
+        return _problem(HTTPStatus.INTERNAL_SERVER_ERROR, "Fact pipeline failure", str(exc)).to_response()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Unexpected fact generation error")
+        return _problem(
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            "Internal server error",
+            "Failed to generate facts",
+        ).to_response()
+
+    return {"output": {"text": text}}
+
+
+__all__ = ["ProblemDetails", "get_fact_pipeline", "generate", "router"]

--- a/tests/api/test_generate.py
+++ b/tests/api/test_generate.py
@@ -1,0 +1,62 @@
+"""Integration tests for the fact generation endpoint."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+
+from facts import NoFactsFoundError
+from factsynth_ultimate.api.v1.generate import get_fact_pipeline
+
+
+class StubPipeline:
+    """Minimal pipeline stub that records queries and returns a preset result."""
+
+    def __init__(self, result: str = "synthesized fact.", error: Exception | None = None) -> None:
+        self._result = result
+        self._error = error
+        self.queries: list[str] = []
+
+    def run(self, query: str) -> str:
+        self.queries.append(query)
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+@pytest.mark.anyio
+async def test_generate_returns_pipeline_output(client, base_headers):
+    pipeline = StubPipeline(result="Curated facts about Kyiv.")
+    app = client._transport.app
+    app.dependency_overrides[get_fact_pipeline] = lambda: pipeline
+    try:
+        response = await client.post(
+            "/v1/generate", headers=base_headers, json={"text": "Kyiv"}
+        )
+    finally:
+        app.dependency_overrides.pop(get_fact_pipeline, None)
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == {"output": {"text": "Curated facts about Kyiv."}}
+    assert pipeline.queries == ["Kyiv"]
+
+
+@pytest.mark.anyio
+async def test_generate_maps_pipeline_error_to_problem_details(client, base_headers):
+    pipeline = StubPipeline(error=NoFactsFoundError("no supporting knowledge"))
+    app = client._transport.app
+    app.dependency_overrides[get_fact_pipeline] = lambda: pipeline
+    try:
+        response = await client.post(
+            "/v1/generate", headers=base_headers, json={"text": "unknown"}
+        )
+    finally:
+        app.dependency_overrides.pop(get_fact_pipeline, None)
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    payload = response.json()
+    assert payload["status"] == HTTPStatus.NOT_FOUND
+    assert payload["title"] == "Facts not found"
+    assert payload["detail"] == "no supporting knowledge"
+    assert payload["type"] == "about:blank"


### PR DESCRIPTION
## Summary
- introduce a reusable `FactPipeline` with search, ranking, aggregation and formatting stages
- expose a dedicated `/v1/generate` router that injects the pipeline and maps failures to RFC 9457 problem details
- add API tests covering successful generation and pipeline failure handling

## Testing
- `PYTEST_ADDOPTS="--no-cov" pytest tests/api/test_generate.py`
- `pytest` *(fails: property-based rate limit test asserts on existing middleware implementation)*

------
https://chatgpt.com/codex/tasks/task_e_68c837011da48329ab9f4ba7058962d0