### PR TITLE
Add WebSocket authentication and session rate limiting

### DIFF
--- a/src/factsynth_ultimate/auth/__init__.py
+++ b/src/factsynth_ultimate/auth/__init__.py
@@ -1,0 +1,17 @@
+"""Authentication helpers for websocket connections."""
+
+from .ws import (
+    WebSocketAuthError,
+    WebSocketUser,
+    authenticate_ws,
+    reset_ws_registry,
+    set_ws_registry,
+)
+
+__all__ = [
+    "WebSocketAuthError",
+    "WebSocketUser",
+    "authenticate_ws",
+    "reset_ws_registry",
+    "set_ws_registry",
+]

--- a/src/factsynth_ultimate/auth/ws.py
+++ b/src/factsynth_ultimate/auth/ws.py
@@ -1,0 +1,86 @@
+"""WebSocket authentication utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping
+
+from ..core.settings import load_settings
+
+
+@dataclass(frozen=True, slots=True)
+class WebSocketUser:
+    """Immutable user record returned after successful authentication."""
+
+    api_key: str
+    organization: str
+    status: str = "active"
+
+
+class WebSocketAuthError(Exception):
+    """Exception raised when websocket authentication fails."""
+
+    def __init__(self, code: int, reason: str) -> None:
+        super().__init__(reason)
+        self.code = int(code)
+        self.reason = reason
+
+
+_REGISTRY: MutableMapping[str, WebSocketUser] | None = None
+
+
+def _default_registry() -> MutableMapping[str, WebSocketUser]:
+    settings = load_settings()
+    key = settings.api_key
+    user = WebSocketUser(api_key=key, organization="default", status="active")
+    return {key.casefold(): user}
+
+
+def set_ws_registry(registry: Mapping[str, WebSocketUser]) -> None:
+    """Override the authentication registry (used by tests)."""
+
+    global _REGISTRY
+    _REGISTRY = {key.casefold(): value for key, value in registry.items()}
+
+
+def reset_ws_registry() -> None:
+    """Reset the registry to its default lazy-loaded state."""
+
+    global _REGISTRY
+    _REGISTRY = None
+
+
+def _registry() -> MutableMapping[str, WebSocketUser]:
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = _default_registry()
+    return _REGISTRY
+
+
+def authenticate_ws(api_key: str | None) -> WebSocketUser:
+    """Validate ``api_key`` and return the associated :class:`WebSocketUser`."""
+
+    key = (api_key or "").strip()
+    if not key:
+        raise WebSocketAuthError(4401, "Missing API key")
+
+    entry = _registry().get(key.casefold())
+    if entry is None:
+        raise WebSocketAuthError(4401, "Invalid API key")
+
+    if not entry.organization:
+        raise WebSocketAuthError(4403, "Organization required")
+
+    if entry.status.casefold() not in {"active", "enabled"}:
+        raise WebSocketAuthError(4429, "API key disabled")
+
+    return entry
+
+
+__all__ = [
+    "WebSocketAuthError",
+    "WebSocketUser",
+    "authenticate_ws",
+    "reset_ws_registry",
+    "set_ws_registry",
+]

--- a/src/factsynth_ultimate/core/logging.py
+++ b/src/factsynth_ultimate/core/logging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import suppress
 
 from pythonjsonlogger import jsonlogger
 
@@ -31,3 +32,15 @@ def setup_logging() -> None:
     root.setLevel(level)
     root.handlers.clear()
     root.addHandler(handler)
+
+    audit_logger = logging.getLogger("factsynth.audit")
+    for existing in list(audit_logger.handlers):
+        audit_logger.removeHandler(existing)
+        with suppress(Exception):
+            existing.close()
+    audit_handler = logging.FileHandler("audit.log", encoding="utf-8")
+    audit_handler.setFormatter(jsonlogger.JsonFormatter())
+    audit_handler.addFilter(RequestIdFilter())
+    audit_logger.addHandler(audit_handler)
+    audit_logger.setLevel(level)
+    audit_logger.propagate = False

--- a/tests/auth/test_ws_auth.py
+++ b/tests/auth/test_ws_auth.py
@@ -1,0 +1,67 @@
+import pytest
+
+from factsynth_ultimate.auth import ws
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    ws.reset_ws_registry()
+    yield
+    ws.reset_ws_registry()
+
+
+def test_authenticate_ws_success():
+    user = ws.WebSocketUser(api_key="alpha", organization="team", status="active")
+    ws.set_ws_registry({user.api_key: user})
+
+    authenticated = ws.authenticate_ws("alpha")
+
+    assert authenticated is user
+    assert authenticated.organization == "team"
+
+
+def test_authenticate_ws_missing_key():
+    with pytest.raises(ws.WebSocketAuthError) as excinfo:
+        ws.authenticate_ws("")
+
+    err = excinfo.value
+    assert err.code == 4401
+    assert "Missing" in err.reason
+
+
+def test_authenticate_ws_unknown_key():
+    ws.set_ws_registry({})
+
+    with pytest.raises(ws.WebSocketAuthError) as excinfo:
+        ws.authenticate_ws("does-not-exist")
+
+    assert excinfo.value.code == 4401
+
+
+def test_authenticate_ws_requires_organization():
+    user = ws.WebSocketUser(api_key="beta", organization="", status="active")
+    ws.set_ws_registry({user.api_key: user})
+
+    with pytest.raises(ws.WebSocketAuthError) as excinfo:
+        ws.authenticate_ws("beta")
+
+    assert excinfo.value.code == 4403
+
+
+def test_authenticate_ws_requires_active_status():
+    user = ws.WebSocketUser(api_key="gamma", organization="org", status="disabled")
+    ws.set_ws_registry({user.api_key: user})
+
+    with pytest.raises(ws.WebSocketAuthError) as excinfo:
+        ws.authenticate_ws("gamma")
+
+    assert excinfo.value.code == 4429
+
+
+def test_authenticate_ws_case_insensitive_lookup():
+    user = ws.WebSocketUser(api_key="DeltaKey", organization="org", status="active")
+    ws.set_ws_registry({user.api_key: user})
+
+    authenticated = ws.authenticate_ws("deltakey")
+
+    assert authenticated is user

--- a/tests/stream/test_ws_limits.py
+++ b/tests/stream/test_ws_limits.py
@@ -1,0 +1,107 @@
+import contextlib
+import logging
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from factsynth_ultimate.api import routers
+from factsynth_ultimate.api.v1 import generate
+from factsynth_ultimate.app import create_app
+from factsynth_ultimate.auth import ws as ws_auth
+
+
+class DummyPipeline:
+    def __init__(self, response: str = "echo") -> None:
+        self._response = response
+        self.calls = 0
+        self.queries: list[str] = []
+
+    def run(self, query: str) -> str:
+        self.calls += 1
+        self.queries.append(query)
+        return self._response if self._response else query
+
+
+def _flush_audit_log() -> list[str]:
+    logger = logging.getLogger("factsynth.audit")
+    for handler in logger.handlers:
+        with contextlib.suppress(Exception):
+            handler.flush()
+    path = Path("audit.log")
+    if not path.exists():
+        return []
+    content = path.read_text(encoding="utf-8")
+    return [line for line in content.splitlines() if line.strip()]
+
+
+def _consume_until_end(ws) -> None:
+    start = ws.receive_json()
+    assert start["event"] == "start"
+    while True:
+        message = ws.receive_json()
+        if message.get("event") in {"end", "error"}:
+            break
+
+
+@pytest.fixture(autouse=True)
+def _clean_audit_log():
+    Path("audit.log").unlink(missing_ok=True)
+    yield
+    Path("audit.log").unlink(missing_ok=True)
+
+
+@pytest.fixture(autouse=True)
+def _reset_ws_registry():
+    ws_auth.reset_ws_registry()
+    yield
+    ws_auth.reset_ws_registry()
+
+
+def test_ws_scope_contains_authenticated_user():
+    user = ws_auth.WebSocketUser(api_key="change-me", organization="qa", status="active")
+    ws_auth.set_ws_registry({user.api_key: user})
+
+    pipeline = DummyPipeline("hello world")
+    app = create_app()
+    app.dependency_overrides[routers.get_fact_pipeline] = lambda: pipeline
+    app.dependency_overrides[generate.get_fact_pipeline] = lambda: pipeline
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/stream", headers={"x-api-key": "change-me"}) as ws:
+            stored = ws.scope.get("user")
+            assert stored is user
+            ws.send_json({"text": "alpha"})
+            _consume_until_end(ws)
+
+
+def test_ws_rate_limit_triggers_and_logs():
+    user = ws_auth.WebSocketUser(api_key="change-me", organization="ops", status="active")
+    ws_auth.set_ws_registry({user.api_key: user})
+
+    pipeline = DummyPipeline("alpha beta gamma")
+    app = create_app()
+    app.dependency_overrides[routers.get_fact_pipeline] = lambda: pipeline
+    app.dependency_overrides[generate.get_fact_pipeline] = lambda: pipeline
+    app.state.ws_rate_limiter = routers.SessionRateLimiter(limit=1, window=60.0)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/stream", headers={"x-api-key": "change-me"}) as ws:
+            ws.send_json({"text": "one"})
+            _consume_until_end(ws)
+            assert pipeline.calls == 1
+
+            ws.send_json({"text": "two"})
+            error = ws.receive_json()
+            assert error.get("event") == "error"
+            assert error.get("message") == "Rate limit exceeded"
+            assert error.get("replay") is False
+
+            with pytest.raises((RuntimeError, WebSocketDisconnect)):
+                ws.receive_json()
+
+    entries = _flush_audit_log()
+    assert any("ws_connect" in line for line in entries)
+    assert any("ws_rate_limit" in line for line in entries)
+    assert any("ws_disconnect_rate_limited" in line for line in entries)


### PR DESCRIPTION
## Summary
- add a dedicated WebSocket authentication helper that validates API keys, organizations, and key status before accepting a connection
- update the /ws/stream endpoint to store authenticated user details in the scope, enforce per-client session rate limiting, and audit connection lifecycle events
- configure audit logging to write to audit.log during app setup and add regression tests that cover WebSocket auth and rate-limit behavior

## Testing
- pytest --no-cov tests/auth/test_ws_auth.py tests/stream/test_ws_limits.py tests/stream/test_ws.py

------
https://chatgpt.com/codex/tasks/task_e_68c90f5b24b08329a89565c3285d8ddc