### PR TITLE
Enhance callback allowlist diagnostics and tests

### DIFF
--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings.sources import NoDecode
 
 from factsynth_ultimate.config import ConfigError, load_config
 
@@ -45,7 +46,7 @@ class Settings(BaseSettings):
     skip_auth_paths: list[str] = Field(
         default_factory=lambda: ["/v1/healthz", "/metrics"], env="SKIP_AUTH_PATHS"
     )
-    callback_url_allowed_hosts: list[str] = Field(
+    callback_url_allowed_hosts: Annotated[list[str], NoDecode] = Field(
         default_factory=_default_callback_allowed_hosts,
         env="CALLBACK_URL_ALLOWED_HOSTS",
     )

--- a/src/factsynth_ultimate/validators/callback.py
+++ b/src/factsynth_ultimate/validators/callback.py
@@ -14,6 +14,34 @@ logger = logging.getLogger(__name__)
 ALLOWED_SCHEMES = {"http", "https"}
 
 
+def _reject(
+    url: str,
+    *,
+    detail: str,
+    reason: str,
+    title: str = "Invalid callback URL",
+    exc: Exception | None = None,
+    extras: dict[str, object] | None = None,
+) -> ProblemDetails:
+    """Return a :class:`ProblemDetails` describing a rejection."""
+
+    if exc is None:
+        logger.warning("Rejecting callback URL %s: %s", url, detail)
+    else:  # pragma: no cover - defensive, depends on urllib internals
+        logger.warning("Rejecting callback URL %s: %s", url, detail, exc_info=exc)
+
+    payload: dict[str, object] = {"reason": reason}
+    if extras:
+        payload.update(extras)
+
+    return ProblemDetails(
+        title=title,
+        detail=detail,
+        status=int(HTTPStatus.BAD_REQUEST),
+        extras=payload,
+    )
+
+
 def validate_callback_url(url: str, allowed_hosts: Collection[str]) -> ProblemDetails | None:
     """Validate ``url`` against the configured allowlist.
 
@@ -30,12 +58,7 @@ def validate_callback_url(url: str, allowed_hosts: Collection[str]) -> ProblemDe
         parsed = urlparse(url)
     except Exception as exc:  # pragma: no cover - defensive guard
         detail = "Callback URL is malformed"
-        logger.warning("Rejecting callback URL %s: %s", url, detail, exc_info=exc)
-        return ProblemDetails(
-            title="Invalid callback URL",
-            detail=detail,
-            status=int(HTTPStatus.BAD_REQUEST),
-        )
+        return _reject(url, detail=detail, reason="invalid_url", exc=exc)
 
     scheme = (parsed.scheme or "").lower()
     if scheme not in ALLOWED_SCHEMES:
@@ -43,47 +66,44 @@ def validate_callback_url(url: str, allowed_hosts: Collection[str]) -> ProblemDe
             f"Callback URL scheme '{scheme or '[missing]'}' is not allowed. "
             f"Allowed schemes: {', '.join(sorted(ALLOWED_SCHEMES))}."
         )
-        logger.warning("Rejecting callback URL %s: %s", url, detail)
-        return ProblemDetails(
-            title="Invalid callback URL",
+        return _reject(
+            url,
             detail=detail,
-            status=int(HTTPStatus.BAD_REQUEST),
+            reason="scheme_not_allowed",
+            extras={"allowed_schemes": sorted(ALLOWED_SCHEMES)},
         )
 
     host = (parsed.hostname or "").lower()
     if not host:
         detail = "Callback URL must include a host component"
-        logger.warning("Rejecting callback URL %s: %s", url, detail)
-        return ProblemDetails(
-            title="Invalid callback URL",
-            detail=detail,
-            status=int(HTTPStatus.BAD_REQUEST),
-        )
+        return _reject(url, detail=detail, reason="missing_host")
 
     normalized_allowlist = {item.lower() for item in allowed_hosts if item}
     if not normalized_allowlist:
         detail = "Callback host allowlist is empty"
-        logger.warning("Rejecting callback URL %s: %s", url, detail)
-        return ProblemDetails(
-            title="Callback host rejected",
+        return _reject(
+            url,
             detail=detail,
-            status=int(HTTPStatus.BAD_REQUEST),
+            reason="allowlist_empty",
+            title="Callback host rejected",
         )
 
     if host not in normalized_allowlist:
-        allowed_preview = ", ".join(sorted(normalized_allowlist))
+        allowed_preview = sorted(normalized_allowlist)
         detail = (
             f"Callback host '{host}' is not allowed. "
-            f"Configured allowlist: {allowed_preview}."
+            f"Configured allowlist: {', '.join(allowed_preview)}."
         )
-        logger.warning("Rejecting callback URL %s: %s", url, detail)
-        return ProblemDetails(
-            title="Callback host rejected",
+        return _reject(
+            url,
             detail=detail,
-            status=int(HTTPStatus.BAD_REQUEST),
+            reason="host_not_allowed",
+            title="Callback host rejected",
+            extras={"host": host, "allowed_hosts": allowed_preview},
         )
 
     return None
 
 
 __all__ = ["validate_callback_url", "ALLOWED_SCHEMES"]
+

--- a/tests/callbacks/test_allowlist.py
+++ b/tests/callbacks/test_allowlist.py
@@ -28,18 +28,19 @@ def test_cli_callbacks_allow_deduplicates(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("url", "allowed", "expect_problem"),
+    ("url", "allowed", "expect_problem", "expected_reason"),
     [
-        ("https://example.com/cb", ["example.com"], False),
-        ("https://evil.com/cb", ["example.com"], True),
-        ("https://example.com/cb", [], True),
+        ("https://example.com/cb", ["example.com"], False, None),
+        ("https://evil.com/cb", ["example.com"], True, "host_not_allowed"),
+        ("https://example.com/cb", [], True, "allowlist_empty"),
     ],
 )
-def test_validate_callback_url_allowlist(url, allowed, expect_problem):
+def test_validate_callback_url_allowlist(url, allowed, expect_problem, expected_reason):
     problem = validate_callback_url(url, allowed)
     assert (problem is not None) is expect_problem
     if problem:
         assert "callback" in problem.detail.lower()
+        assert problem.extras["reason"] == expected_reason
 
 
 def test_settings_respects_saved_allowlist(tmp_path, monkeypatch):

--- a/tests/test_validate_callback_url.py
+++ b/tests/test_validate_callback_url.py
@@ -13,24 +13,37 @@ def test_validate_callback_url_disallowed_scheme():
     assert problem is not None
     assert problem.status == HTTPStatus.BAD_REQUEST
     assert "scheme" in problem.detail.lower()
+    assert problem.extras == {
+        "reason": "scheme_not_allowed",
+        "allowed_schemes": ["http", "https"],
+    }
 
 
 def test_validate_callback_url_host_mismatch():
     problem = validate_callback_url("https://b.com", ["a.com"])
     assert problem is not None
     assert "b.com" in problem.detail
+    assert problem.extras == {
+        "reason": "host_not_allowed",
+        "host": "b.com",
+        "allowed_hosts": ["a.com"],
+    }
 
 
 def test_validate_callback_url_empty_allowlist():
     problem = validate_callback_url("https://example.com", [])
     assert problem is not None
     assert "empty" in problem.detail.lower()
+    assert problem.extras == {
+        "reason": "allowlist_empty",
+    }
 
 
 def test_validate_callback_url_missing_host():
     problem = validate_callback_url("https:///path", ["a.com"])
     assert problem is not None
     assert "host" in problem.detail.lower()
+    assert problem.extras == {"reason": "missing_host"}
 
 
 def test_validate_callback_url_dynamic_allowlist(monkeypatch):


### PR DESCRIPTION
## Summary
- enrich callback URL validation with structured rejection reasons returned to clients
- mark callback allowlist settings to bypass JSON decoding so simple env strings are accepted
- extend callback allowlist unit tests to cover rejection metadata and CLI behaviour

## Testing
- `pytest -o addopts="" tests/callbacks/test_allowlist.py tests/test_validate_callback_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68c919e4d1d88329980184bca98690ad