### PR TITLE
Ensure dependency snapshots stay current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,12 @@ jobs:
           pip install pre-commit
           pre-commit run --all-files --show-diff-on-failure
 
-      - name: Check lockfile
-        if: hashFiles('requirements.lock','pyproject.toml') != ''
+      - name: Verify dependency artifacts
+        if: hashFiles('pyproject.toml','requirements.lock','requirements-dev.txt') != ''
         run: |
-          pip-compile pyproject.toml --allow-unsafe --extra=dev --extra=isr --extra=numpy --generate-hashes --output-file=requirements.lock
-          git diff --exit-code requirements.lock
-
-      - name: Check dev requirements
-        if: hashFiles('pyproject.toml','requirements-dev.txt') != ''
-        run: |
+          pre-commit run pip-compile --files pyproject.toml requirements.lock
           scripts/update_dev_requirements.sh
-          git diff --exit-code requirements-dev.txt
+          git diff --exit-code
 
       - name: Lint JS
         if: hashFiles('package.json') != ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,13 @@ Run checks on staged files:
 pre-commit run --files <path/to/file.py>
 ```
 
+Before committing, refresh dependency artifacts:
+
+```bash
+pre-commit run pip-compile --files pyproject.toml requirements.lock
+scripts/update_dev_requirements.sh
+```
+
 ## Branch protection
 
 The `main` branch is protected to keep the codebase stable:


### PR DESCRIPTION
## Summary
- run the dependency snapshot verification in CI via the dedicated pre-commit hook and the dev requirements script
- document the dependency refresh commands contributors should run before committing

## Testing
- pre-commit run pip-compile --files pyproject.toml requirements.lock *(fails: junit-xml dependency conflict)*
- scripts/update_dev_requirements.sh


------
https://chatgpt.com/codex/tasks/task_e_68c9247cc3b0832988a45f7846dadc8f