### PR TITLE
Clean duplicate imports in callback validation test

### DIFF
--- a/tests/test_callback_validation.py
+++ b/tests/test_callback_validation.py
@@ -1,14 +1,11 @@
 import os
 from http import HTTPStatus
-from http import HTTPStatus
-import os
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from factsynth_ultimate.app import create_app
-
 
 pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 


### PR DESCRIPTION
## Summary
- remove duplicate imports of `os` and `HTTPStatus` in the callback validation tests to keep a single declaration each

## Testing
- ruff check --fix tests/test_callback_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68c928f8232c83299d845aae1a496281