### PR TITLE
Disable fail fast in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"


### PR DESCRIPTION
## Summary
- disable fail-fast so each Python job runs independently within the CI matrix

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c92ef0fb288329adfd31f560145a51