### PR TITLE
Collect pytest coverage report in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,15 @@ jobs:
         if: hashFiles('tests/**','pyproject.toml','requirements.txt') != ''
         run: |
           pip install pytest pytest-cov hypothesis
-          pytest --ignore=tests/property --ignore=tests/test_tokenization.py
+          pytest --cov --cov-report=xml --ignore=tests/property --ignore=tests/test_tokenization.py
+
+      - name: Upload coverage artifact
+        if: hashFiles('tests/**','pyproject.toml','requirements.txt') != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml
+          if-no-files-found: warn
 
       - name: Property tests
         if: hashFiles('tests/property/**','tests/test_tokenization.py','pyproject.toml','requirements.txt') != ''


### PR DESCRIPTION
## Summary
- update the Python unit test step to emit coverage XML
- upload the generated coverage.xml artifact for each Python version matrix job

## Testing
- pytest --cov --cov-report=xml --ignore=tests/property --ignore=tests/test_tokenization.py *(fails: ModuleNotFoundError: No module named 'time_machine')*


------
https://chatgpt.com/codex/tasks/task_e_68c92ef2562c83299f4c7e608ce7d933