### PR TITLE
Reset fakeredis state between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import random
 import string
 
+import fakeredis
 import pytest
 import time_machine
 from httpx import ASGITransport, AsyncClient, MockTransport, Response
@@ -121,4 +122,9 @@ def _stub_external_api(httpx_mock) -> None:
 
 @pytest.fixture(autouse=True)
 def _reset_fake_redis() -> None:
-    pass
+    client = fakeredis.FakeRedis()
+    client.flushall()
+    try:
+        yield
+    finally:
+        client.flushall()


### PR DESCRIPTION
## Summary
- import `fakeredis` in the shared pytest configuration
- flush the in-memory redis state before and after each test so counters start clean

## Testing
- pytest --no-cov tests/middleware/test_rate_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68c93feab4e083299d66457f54befd33