### PR TITLE
Convert callback tests to async

### DIFF
--- a/tests/test_nli.py
+++ b/tests/test_nli.py
@@ -1,5 +1,6 @@
-import asyncio
 import logging
+
+import pytest
 
 from factsynth_ultimate.services.nli import NLI
 
@@ -7,7 +8,8 @@ EXPECTED_SCORE = 0.42
 THRESHOLD = 0.9
 
 
-def test_nli_uses_async_classifier(httpx_mock):
+@pytest.mark.anyio
+async def test_nli_uses_async_classifier(httpx_mock):
     httpx_mock.reset()
     httpx_mock._options.assert_all_responses_were_requested = False
 
@@ -15,11 +17,12 @@ def test_nli_uses_async_classifier(httpx_mock):
         return EXPECTED_SCORE
 
     nli = NLI(classifier)
-    score = asyncio.run(nli.classify("a", "b"))
+    score = await nli.classify("a", "b")
     assert score == EXPECTED_SCORE
 
 
-def test_nli_fallback_on_error(httpx_mock, caplog):
+@pytest.mark.anyio
+async def test_nli_fallback_on_error(httpx_mock, caplog):
     httpx_mock.reset()
     httpx_mock._options.assert_all_responses_were_requested = False
 
@@ -28,17 +31,16 @@ def test_nli_fallback_on_error(httpx_mock, caplog):
 
     nli = NLI(failing_classifier)
     with caplog.at_level(logging.ERROR):
-        score = asyncio.run(
-            nli.classify(
-                "Cats are animals", "Cats are animals", request_id="RID-123"
-            )
+        score = await nli.classify(
+            "Cats are animals", "Cats are animals", request_id="RID-123"
         )
     assert score > THRESHOLD
     record = next(r for r in caplog.records if r.message == "classifier_error")
     assert record.request_id == "RID-123"
 
 
-def test_nli_fallback_on_custom_classifier_error(httpx_mock):
+@pytest.mark.anyio
+async def test_nli_fallback_on_custom_classifier_error(httpx_mock):
     httpx_mock.reset()
     httpx_mock._options.assert_all_responses_were_requested = False
 
@@ -50,5 +52,5 @@ def test_nli_fallback_on_custom_classifier_error(httpx_mock):
             raise CustomError("boom")
 
     nli = NLI(CustomClassifier())
-    score = asyncio.run(nli.classify("Cats are animals", "Cats are animals"))
+    score = await nli.classify("Cats are animals", "Cats are animals")
     assert score > THRESHOLD

--- a/tests/test_post_callback_logging.py
+++ b/tests/test_post_callback_logging.py
@@ -1,28 +1,33 @@
-import asyncio
 import logging
 from unittest.mock import AsyncMock
 
+import pytest
 from httpx import ConnectError
 
 from factsynth_ultimate.api import routers
 
 
-def test_post_callback_logs_and_retries(caplog, monkeypatch):
+@pytest.mark.anyio
+async def test_post_callback_logs_and_retries(caplog, monkeypatch):
     client = AsyncMock()
     client.post.side_effect = [ConnectError("fail1"), ConnectError("fail2")]
 
     ctx = AsyncMock()
     ctx.__aenter__.return_value = client
+    ctx.__aexit__.return_value = None
 
     monkeypatch.setattr(routers.httpx, "AsyncClient", lambda **_: ctx)
-    monkeypatch.setattr(routers, "_sleep", AsyncMock())
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(routers, "_sleep", sleep_mock)
 
     caplog.set_level(logging.WARNING)
     attempts = 2
 
-    asyncio.run(routers._post_callback("http://cb", {}, attempts=attempts, base_delay=0.1, max_delay=0.2))
+    await routers._post_callback(
+        "http://cb", {}, attempts=attempts, base_delay=0.1, max_delay=0.2
+    )
 
-    assert client.post.call_count == attempts
+    assert client.post.await_count == attempts
 
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     errors = [r for r in caplog.records if r.levelno == logging.ERROR]
@@ -30,4 +35,7 @@ def test_post_callback_logs_and_retries(caplog, monkeypatch):
     assert len(warnings) == attempts and len(errors) == 1
     assert "fail1" in warnings[0].message and "fail2" in warnings[1].message
     assert "fail2" in errors[0].message
+    assert sleep_mock.await_count == attempts - 1
+    ctx.__aenter__.assert_awaited_once()
+    ctx.__aexit__.assert_awaited_once()
 

--- a/tests/test_retry_behaviors.py
+++ b/tests/test_retry_behaviors.py
@@ -1,17 +1,19 @@
-import asyncio
 from unittest.mock import AsyncMock
 
+import pytest
 from httpx import ConnectError
 
 from factsynth_ultimate.api import routers
 
 
-def test_delay_jitter(monkeypatch):
+@pytest.mark.anyio
+async def test_delay_jitter(monkeypatch):
     client = AsyncMock()
     client.post.side_effect = ConnectError("fail")
 
     ctx = AsyncMock()
     ctx.__aenter__.return_value = client
+    ctx.__aexit__.return_value = None
 
     monkeypatch.setattr(routers.httpx, "AsyncClient", lambda **_: ctx)
 
@@ -21,22 +23,24 @@ def test_delay_jitter(monkeypatch):
     factor = 1.1
     monkeypatch.setattr(routers.random, "uniform", lambda _a, _b: factor)
 
-    asyncio.run(
-        routers._post_callback(
-            "http://cb", {}, attempts=2, base_delay=1.0, max_delay=2.0
-        )
+    await routers._post_callback(
+        "http://cb", {}, attempts=2, base_delay=1.0, max_delay=2.0
     )
 
-    sleep_mock.assert_called_once()
-    assert sleep_mock.call_args.args[0] == factor
+    sleep_mock.assert_awaited_once()
+    assert sleep_mock.await_args.args[0] == factor
+    ctx.__aenter__.assert_awaited_once()
+    ctx.__aexit__.assert_awaited_once()
 
 
-def test_retry_respects_max_elapsed(monkeypatch):
+@pytest.mark.anyio
+async def test_retry_respects_max_elapsed(monkeypatch):
     client = AsyncMock()
     client.post.side_effect = ConnectError("fail")
 
     ctx = AsyncMock()
     ctx.__aenter__.return_value = client
+    ctx.__aexit__.return_value = None
 
     monkeypatch.setattr(routers.httpx, "AsyncClient", lambda **_: ctx)
 
@@ -58,18 +62,18 @@ def test_retry_respects_max_elapsed(monkeypatch):
     factor = 1.5
     monkeypatch.setattr(routers.random, "uniform", lambda _a, _b: factor)
 
-    asyncio.run(
-        routers._post_callback(
-            "http://cb",
-            {},
-            attempts=10,
-            base_delay=0.5,
-            max_delay=5.0,
-            max_elapsed=1.0,
-        )
+    await routers._post_callback(
+        "http://cb",
+        {},
+        attempts=10,
+        base_delay=0.5,
+        max_delay=5.0,
+        max_elapsed=1.0,
     )
 
     expected_attempts = 2
     expected_sleeps = [0.75, 0.25]
-    assert client.post.call_count == expected_attempts
+    assert client.post.await_count == expected_attempts
     assert sleep_calls == expected_sleeps
+    ctx.__aenter__.assert_awaited_once()
+    ctx.__aexit__.assert_awaited_once()

--- a/tests/test_webhook_retry.py
+++ b/tests/test_webhook_retry.py
@@ -1,27 +1,35 @@
-import asyncio
 import logging
 from unittest.mock import AsyncMock
 
+import pytest
 from httpx import ConnectError
 
 from factsynth_ultimate.api import routers
 
 
-def test_webhook_retry_failure(caplog, monkeypatch):
+@pytest.mark.anyio
+async def test_webhook_retry_failure(caplog, monkeypatch):
     client = AsyncMock()
     client.post.side_effect = ConnectError("boom")
     ctx = AsyncMock()
     ctx.__aenter__.return_value = client
+    ctx.__aexit__.return_value = None
 
     monkeypatch.setattr(routers.httpx, "AsyncClient", lambda **_: ctx)
-    monkeypatch.setattr(routers, "_sleep", AsyncMock())
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(routers, "_sleep", sleep_mock)
 
     caplog.set_level(logging.WARNING)
     attempts = 3
 
-    asyncio.run(routers._post_callback("http://cb", {}, attempts=attempts, base_delay=0.0, max_delay=0.0))
+    await routers._post_callback(
+        "http://cb", {}, attempts=attempts, base_delay=0.0, max_delay=0.0
+    )
 
-    assert client.post.call_count == attempts
+    assert client.post.await_count == attempts
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     errors = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert len(warnings) == attempts and len(errors) == 1
+    assert sleep_mock.await_count == attempts - 1
+    ctx.__aenter__.assert_awaited_once()
+    ctx.__aexit__.assert_awaited_once()


### PR DESCRIPTION
## Summary
- convert callback and NLI tests to `async def` with `pytest.mark.anyio`
- replace `asyncio.run` usage with direct `await` in tests and ensure async resources close via context manager assertions

## Testing
- pytest --no-cov tests/test_retry_behaviors.py tests/test_nli.py tests/test_webhook_retry.py tests/test_post_callback_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68c93fecd2f8832994962a3202613e7f