### PR TITLE
Enhance OpenAPI contract testing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ markers =
     smoke: stream smoke tests
     slow: lengthy streams/benchmarks
     fairness: control set fairness tests
+    contract: API contract validation tests
+    httpx_mock: httpx mock plugin marker

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -1,21 +1,62 @@
+import os
+
 import pytest
+from httpx import AsyncClient
 
 try:
     import schemathesis
 except ModuleNotFoundError as e:  # pragma: no cover - dependency missing in some envs
     pytest.skip(f"Missing dependency: {e}", allow_module_level=True)
 
-OPENAPI_SPEC = {
-    "openapi": "3.1.0",
-    "info": {"title": "stub", "version": "0.1.0"},
-    "paths": {"/v1/score": {"post": {"responses": {"200": {"description": "OK"}}}}},
+from factsynth_ultimate.app import create_app
+from hypothesis import settings
+
+if not hasattr(schemathesis, "from_uri"):
+    schemathesis.from_uri = schemathesis.openapi.from_asgi  # type: ignore[attr-defined]
+
+pytestmark = [
+    pytest.mark.httpx_mock(assert_all_responses_were_requested=False),
+    pytest.mark.contract,
+]
+
+API_KEY = os.getenv("API_KEY", "change-me")
+DEFAULT_CONTRACT_HEADERS = {
+    "x-api-key": API_KEY,
+    "content-type": "application/json",
 }
 
-schema = schemathesis.openapi.from_dict(OPENAPI_SPEC)
-schema.validate()
 
-pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+async def _load_openapi_document(
+    client: AsyncClient, *, headers: dict[str, str] | None = None
+) -> dict:
+    response = await client.get("/openapi.json", headers=headers)
+    response.raise_for_status()
+    return response.json()
 
 
-def test_openapi_schema_has_operations() -> None:
-    assert list(schema.get_all_operations())
+@pytest.fixture()
+async def openapi_schema(
+    client: AsyncClient, base_headers: dict[str, str]
+) -> schemathesis.BaseSchema:
+    document = await _load_openapi_document(client, headers=base_headers)
+    schema = schemathesis.openapi.from_dict(document)
+    schema.validate()
+    return schema
+
+
+SCHEMA_FROM_URI = schemathesis.from_uri(
+    "/openapi.json", app=create_app(), headers=DEFAULT_CONTRACT_HEADERS
+)
+SCHEMA_FROM_URI.validate()
+
+
+@pytest.mark.anyio
+async def test_openapi_schema_has_operations(openapi_schema: schemathesis.BaseSchema) -> None:
+    assert list(openapi_schema.get_all_operations())
+
+
+@SCHEMA_FROM_URI.parametrize()
+@settings(deadline=None, max_examples=1)
+def test_openapi_contract(case: schemathesis.Case, base_headers: dict[str, str]) -> None:
+    response = case.call(headers=base_headers)
+    assert response.status_code < 500


### PR DESCRIPTION
## Summary
- load the live OpenAPI document through the async client fixture and validate it with Schemathesis
- exercise every documented operation via `schemathesis.from_uri` with default API key headers to guard against 5xx responses
- register a dedicated `contract` pytest marker (and the `httpx_mock` plugin marker) so contract tests can be skipped when desired

## Testing
- pytest tests/test_openapi_contract.py --no-cov


------
https://chatgpt.com/codex/tasks/task_e_68c93fed671083299bb9e742e8eb5cb1