### PR TITLE
Include pytest-asyncio in dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest==8.4.2",
+    "pytest-asyncio==1.0.0",  # asyncio plugin for async tests
     "schemathesis==4.1.4",  # API contract testing
     "websockets==15.0.1",  # WebSocket test client
     "pytest-cov==7.0.0",  # coverage plugin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest==8.4.2
+pytest-asyncio==1.0.0
 schemathesis==4.1.4
 websockets==15.0.1
 pytest-cov==7.0.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -144,6 +144,7 @@ click==8.2.1 \
     --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
     --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
     # via
+    #   mutmut
     #   pip-tools
     #   schemathesis
     #   typer
@@ -312,9 +313,9 @@ httpx==0.28.1 \
     #   factsynth-ultimate-pro (pyproject.toml)
     #   pytest-httpx
     #   schemathesis
-hypothesis==6.138.15 \
-    --hash=sha256:6b0e1aa182eacde87110995a3543530d69ef411f642162a656efcd46c2823ad1 \
-    --hash=sha256:b7cf743d461c319eb251a13c8e1dcf00f4ef7085e4ab5bf5abf102b2a5ffd694
+hypothesis==6.138.17 \
+    --hash=sha256:2419eef387211c63bed091938cf17fa909898f064d320e996bcd90383f5ce3c6 \
+    --hash=sha256:b2cf91f1926445cf4d44f5ec9a955c7f637f93e34247ac04e4fb44d010141c85
     # via
     #   factsynth-ultimate-pro (pyproject.toml)
     #   hypothesis-graphql
@@ -407,6 +408,44 @@ junit-xml==1.9 \
     --hash=sha256:de16a051990d4e25a3982b2dd9e89d671067548718866416faec14d9de56db9f \
     --hash=sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732
     # via schemathesis
+libcst==1.7.0 \
+    --hash=sha256:0456381c939169c4f11caecdb30f7aca6f234640731f8f965849c1631930536b \
+    --hash=sha256:09a5530b40a15dbe6fac842ef2ad87ad561760779380ccf3ade6850854d81406 \
+    --hash=sha256:14e5c1d427c33d50df75be6bc999a7b2d7c6b7840e2361a18a6f354db50cb18e \
+    --hash=sha256:1560598f5c56681adbd32f4b08e9cffcd45a021921d1d784370a7d4d9a2fac11 \
+    --hash=sha256:340054c57abcd42953248af18ed278be651a03b1c2a1616f7e1f1ef90b6018ce \
+    --hash=sha256:3923a341a787c1f454909e726a6213dd59c3db26c6e56d0a1fc4f2f7e96b45d7 \
+    --hash=sha256:3d2ec10015e86a4402c3d2084ede6c7c9268faea1ecb99592fe9e291c515aaa2 \
+    --hash=sha256:4c568e14d29489f09faf4915af18235f805d5aa60fa194023b4fadf3209f0c94 \
+    --hash=sha256:57a6bcfc8ca8a0bb9e89a2dbf63ee8f0c7e8353a130528dcb47c9e59c2dc8c94 \
+    --hash=sha256:5d5ba9314569865effd5baff3a58ceb2cced52228e181824759c68486a7ec8f4 \
+    --hash=sha256:5e22738ec2855803f8242e6bf78057389d10f8954db34bf7079c82abab1b8b95 \
+    --hash=sha256:5e50e6960ecc3ed67f39fec63aa329e772d5d27f8e2334e30f19a94aa14489f1 \
+    --hash=sha256:6137fe549bfbb017283c3cf85419eb0dfaa20a211ad6d525538a2494e248a84b \
+    --hash=sha256:61bfc90c8a4594296f8b68702f494dfdfec6e745a4abc0cfa8069d7f22061424 \
+    --hash=sha256:6523731bfbdbc045ff8649130fe14a46b31ad6925f67acdc0e0d80a0c61719fd \
+    --hash=sha256:71a8f59f3472fe8c0f6e2fad457825ea2ccad8c4c713cca55a91ff2cbfa9bc03 \
+    --hash=sha256:81036e820249937608db7e72d0799180122d40d76d0c0414c454f8aa2ffa9c51 \
+    --hash=sha256:8f6e693281d6e9a62414205fb300ec228ddc902ca9cb965a09f11561dc10aa94 \
+    --hash=sha256:932a4c4508bd4cf5248c99b7218bb86af97d87fefa2bdab7ea8a0c28c270724a \
+    --hash=sha256:93417d36c2a1b70d651d0e970ff73339e8dcd64d341672b68823fa0039665022 \
+    --hash=sha256:9370c23a3f609280c3f2296d61d34dd32afd7a1c9b19e4e29cc35cb2e2544363 \
+    --hash=sha256:94acd51ea1206460c20dea764c59222e62c45ae8a486f22024f063d11a7bca88 \
+    --hash=sha256:9add619a825d6f176774110d79dc3137f353a236c1e3bcd6e063ca6d93d6e0ae \
+    --hash=sha256:9cd5ab15b12a37f0e9994d8847d5670da936a93d98672c442a956fab34ea0c15 \
+    --hash=sha256:a252fa03ea00986f03100379f11e15d381103a09667900fb0fa2076cec19081a \
+    --hash=sha256:a63f44ffa81292f183656234c7f2848653ff45c17d867db83c9335119e28aafa \
+    --hash=sha256:b52692a28d0d958ebfabcf8bfce5fcf2c8582967310d35e6111a6e2d4db96659 \
+    --hash=sha256:c3445dce908fd4971ce9bb5fef5742e26c984027676e3dcf24875fbed1ff7e4c \
+    --hash=sha256:c8d6176a667d2db0132d133dad6bbf965f915f3071559342ca2cdbbec537ed12 \
+    --hash=sha256:ca4e91aa854758040fa6fe7036fbe7f90a36a7d283fa1df8587b6f73084fc997 \
+    --hash=sha256:cdae6e632d222d8db7cb98d7cecb45597c21b8e3841d0c98d4fca79c49dad04b \
+    --hash=sha256:d12ffe199ff677a37abfb6b21aba1407eb02246dc7e6bcaf4f8e24a195ec4ad6 \
+    --hash=sha256:d894c48f682b0061fdb2c983d5e64c30334db6ce0783560dbbb9df0163179c0c \
+    --hash=sha256:e635eadb6043d5f967450af27125811c6ccc7eeb4d8c5fd4f1bece9d96418781 \
+    --hash=sha256:e7d9a796c2f3d5b71dd06b7578e8d1fb1c031d2eb8d59e7b40e288752ae1b210 \
+    --hash=sha256:fa519d4391326329f37860c2f2aaf80cb11a6122d14afa2f4f00dde6fcfa7ae4
+    # via mutmut
 license-expression==30.4.4 \
     --hash=sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4 \
     --hash=sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd
@@ -421,10 +460,17 @@ lineax==0.0.8 \
     # via
     #   diffrax
     #   optimistix
-markdown-it-py==4.0.0 \
+linkify-it-py==2.0.3 \
+    --hash=sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048 \
+    --hash=sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79
+    # via markdown-it-py
+markdown-it-py[linkify,plugins]==4.0.0 \
     --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \
     --hash=sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
-    # via rich
+    # via
+    #   mdit-py-plugins
+    #   rich
+    #   textual
 markupsafe==3.0.2 \
     --hash=sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4 \
     --hash=sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30 \
@@ -488,6 +534,10 @@ markupsafe==3.0.2 \
     --hash=sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430 \
     --hash=sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50
     # via werkzeug
+mdit-py-plugins==0.5.0 \
+    --hash=sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f \
+    --hash=sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6
+    # via markdown-it-py
 mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
@@ -592,6 +642,10 @@ msgpack==1.1.1 \
     --hash=sha256:f5be6b6bc52fad84d010cb45433720327ce886009d862f46b26d4d154001994b \
     --hash=sha256:f6d58656842e1b2ddbe07f43f56b10a60f2ba5826164910968f5933e5178af75
     # via cachecontrol
+mutmut==3.3.1 \
+    --hash=sha256:6aabc3a8f2b6c8eafe7054e1f7348e68aba807dcf12bffb6bfa00e5046d8a6bd \
+    --hash=sha256:b5dd21dff2af5bd1bdec0dccfdf0da82e1428d068a1f485c8138ae248552c9d8
+    # via factsynth-ultimate-pro (pyproject.toml)
 nodeenv==1.9.1 \
     --hash=sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f \
     --hash=sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9
@@ -682,6 +736,7 @@ platformdirs==4.4.0 \
     --hash=sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf
     # via
     #   pip-audit
+    #   textual
     #   virtualenv
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
@@ -823,6 +878,7 @@ pygments==2.19.2 \
     # via
     #   pytest
     #   rich
+    #   textual
 pyparsing==3.2.3 \
     --hash=sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf \
     --hash=sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be
@@ -842,10 +898,16 @@ pytest==8.4.2 \
     --hash=sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79
     # via
     #   factsynth-ultimate-pro (pyproject.toml)
+    #   mutmut
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-httpx
     #   pytest-subtests
     #   schemathesis
+pytest-asyncio==1.0.0 \
+    --hash=sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3 \
+    --hash=sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f
+    # via factsynth-ultimate-pro (pyproject.toml)
 pytest-cov==7.0.0 \
     --hash=sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1 \
     --hash=sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861
@@ -861,14 +923,16 @@ pytest-subtests==0.14.2 \
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
-    # via arrow
+    # via
+    #   arrow
+    #   time-machine
 python-dotenv==1.1.1 \
     --hash=sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc \
     --hash=sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab
     # via pydantic-settings
-python-json-logger==2.0.7 \
-    --hash=sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c \
-    --hash=sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd
+python-json-logger==3.3.0 \
+    --hash=sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84 \
+    --hash=sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7
     # via factsynth-ultimate-pro (pyproject.toml)
 pyyaml==6.0.2 \
     --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
@@ -926,6 +990,7 @@ pyyaml==6.0.2 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via
     #   factsynth-ultimate-pro (pyproject.toml)
+    #   libcst
     #   pre-commit
     #   schemathesis
 redis==6.4.0 \
@@ -1052,6 +1117,7 @@ rich==14.1.0 \
     # via
     #   pip-audit
     #   schemathesis
+    #   textual
     #   typer
 rpds-py==0.27.1 \
     --hash=sha256:008b839781d6c9bf3b6a8984d1d8e56f0ec46dc56df61fd669c49b58ae800400 \
@@ -1275,6 +1341,105 @@ scipy==1.16.1 \
     # via
     #   jax
     #   jaxlib
+setproctitle==1.3.7 \
+    --hash=sha256:00afa6fc507967d8c9d592a887cdc6c1f5742ceac6a4354d111ca0214847732c \
+    --hash=sha256:01f27b5b72505b304152cb0bd7ff410cc4f2d69ac70c21a7fdfa64400a68642d \
+    --hash=sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2 \
+    --hash=sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c \
+    --hash=sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd \
+    --hash=sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f \
+    --hash=sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9 \
+    --hash=sha256:134e7f66703a1d92c0a9a0a417c580f2cc04b93d31d3fc0dd43c3aa194b706e1 \
+    --hash=sha256:13fe37951dda1a45c35d77d06e3da5d90e4f875c4918a7312b3b4556cfa7ff64 \
+    --hash=sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b \
+    --hash=sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e \
+    --hash=sha256:1607b963e7b53e24ec8a2cb4e0ab3ae591d7c6bf0a160feef0551da63452b37f \
+    --hash=sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73 \
+    --hash=sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18 \
+    --hash=sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629 \
+    --hash=sha256:2a4e03bd9aa5d10b8702f00ec1b740691da96b5003432f3000d60c56f1c2b4d3 \
+    --hash=sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e \
+    --hash=sha256:316664d8b24a5c91ee244460bdaf7a74a707adaa9e14fbe0dc0a53168bb9aba1 \
+    --hash=sha256:318ddcf88dafddf33039ad41bc933e1c49b4cb196fe1731a209b753909591680 \
+    --hash=sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee \
+    --hash=sha256:35a2cabcfdea4643d7811cfe9f3d92366d282b38ef5e7e93e25dafb6f97b0a59 \
+    --hash=sha256:376761125ab5dab822d40eaa7d9b7e876627ecd41de8fa5336713b611b47ccef \
+    --hash=sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a \
+    --hash=sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070 \
+    --hash=sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5 \
+    --hash=sha256:47d36e418ab86b3bc7946e27155e281a743274d02cd7e545f5d628a2875d32f9 \
+    --hash=sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29 \
+    --hash=sha256:502b902a0e4c69031b87870ff4986c290ebbb12d6038a70639f09c331b18efb2 \
+    --hash=sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed \
+    --hash=sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416 \
+    --hash=sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4 \
+    --hash=sha256:5ce2613e1361959bff81317dc30a60adb29d8132b6159608a783878fc4bc4bbc \
+    --hash=sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c \
+    --hash=sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309 \
+    --hash=sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698 \
+    --hash=sha256:690b4776f9c15aaf1023bb07d7c5b797681a17af98a4a69e76a1d504e41108b7 \
+    --hash=sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1 \
+    --hash=sha256:6da835e76ae18574859224a75db6e15c4c2aaa66d300a57efeaa4c97ca4c7381 \
+    --hash=sha256:6f1be447456fe1e16c92f5fb479404a850d8f4f4ff47192fde14a59b0bae6a0a \
+    --hash=sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3 \
+    --hash=sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152 \
+    --hash=sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd \
+    --hash=sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17 \
+    --hash=sha256:80b6a562cbc92b289c28f34ce709a16b26b1696e9b9a0542a675ce3a788bdf3f \
+    --hash=sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63 \
+    --hash=sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b \
+    --hash=sha256:83fcd271567d133eb9532d3b067c8a75be175b2b3b271e2812921a05303a693f \
+    --hash=sha256:8ce2e39a40fca82744883834683d833e0eb28623752cc1c21c2ec8f06a890b39 \
+    --hash=sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1 \
+    --hash=sha256:9796732a040f617fc933f9531c9a84bb73c5c27b8074abbe52907076e804b2b7 \
+    --hash=sha256:97a090fed480471bb175689859532709e28c085087e344bca45cf318034f70c4 \
+    --hash=sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300 \
+    --hash=sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c \
+    --hash=sha256:9e02667f6b9fc1238ba753c0f4b0a37ae184ce8f3bbbc38e115d99646b3f4cd3 \
+    --hash=sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0 \
+    --hash=sha256:9e803d1b1e20240a93bac0bc1025363f7f80cb7eab67dfe21efc0686cc59ad7c \
+    --hash=sha256:a05509cfb2059e5d2ddff701d38e474169e9ce2a298cf1b6fd5f3a213a553fe5 \
+    --hash=sha256:a20fb1a3974e2dab857870cf874b325b8705605cb7e7e8bcbb915bca896f52a9 \
+    --hash=sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0 \
+    --hash=sha256:a600eeb4145fb0ee6c287cb82a2884bd4ec5bbb076921e287039dcc7b7cc6dd0 \
+    --hash=sha256:a74714ce836914063c36c8a26ae11383cf8a379698c989fe46883e38a8faa5be \
+    --hash=sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929 \
+    --hash=sha256:a93e4770ac22794cfa651ee53f092d7de7105c76b9fc088bb81ca0dcf698f704 \
+    --hash=sha256:a97200acc6b64ec4cada52c2ecaf1fba1ef9429ce9c542f8a7db5bcaa9dcbd95 \
+    --hash=sha256:acb9097213a8dd3410ed9f0dc147840e45ca9797785272928d4be3f0e69e3be4 \
+    --hash=sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f \
+    --hash=sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a \
+    --hash=sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1 \
+    --hash=sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e \
+    --hash=sha256:b74774ca471c86c09b9d5037c8451fff06bb82cd320d26ae5a01c758088c0d5d \
+    --hash=sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c \
+    --hash=sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8 \
+    --hash=sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e \
+    --hash=sha256:be7e01f3ad8d0e43954bebdb3088cb466633c2f4acdd88647e7fbfcfe9b9729f \
+    --hash=sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29 \
+    --hash=sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922 \
+    --hash=sha256:c4fb90174d176473122e7eef7c6492d53761826f34ff61c81a1c1d66905025d3 \
+    --hash=sha256:c77b3f58a35f20363f6e0a1219b367fbf7e2d2efe3d2c32e1f796447e6061c10 \
+    --hash=sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a \
+    --hash=sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798 \
+    --hash=sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9 \
+    --hash=sha256:cf555b6299f10a6eb44e4f96d2f5a3884c70ce25dc5c8796aaa2f7b40e72cb1b \
+    --hash=sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6 \
+    --hash=sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739 \
+    --hash=sha256:db0fd964fbd3a9f8999b502f65bd2e20883fdb5b1fae3a424e66db9a793ed307 \
+    --hash=sha256:db116850fcf7cca19492030f8d3b4b6e231278e8fe097a043957d22ce1bdf3ee \
+    --hash=sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5 \
+    --hash=sha256:deda9d79d1eb37b688729cac2dba0c137e992ebea960eadb7c2c255524c869e0 \
+    --hash=sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45 \
+    --hash=sha256:eb440c5644a448e6203935ed60466ec8d0df7278cd22dc6cf782d07911bcbea6 \
+    --hash=sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65 \
+    --hash=sha256:f2ae6c3f042fc866cc0fa2bc35ae00d334a9fa56c9d28dfc47d1b4f5ed23e375 \
+    --hash=sha256:f6f268caeabb37ccd824d749e7ce0ec6337c4ed954adba33ec0d90cc46b0ab78 \
+    --hash=sha256:f8d961bba676e07d77665204f36cffaa260f526e7b32d07ab3df6a2c1dfb44ba \
+    --hash=sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f \
+    --hash=sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f \
+    --hash=sha256:ff3c1c32382fb71a200db8bab3df22f32e6ac7ec3170e92fa5b542cf42eed9a2
+    # via mutmut
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -1315,6 +1480,10 @@ starlette-testclient==0.4.1 \
     --hash=sha256:9e993ffe12fab45606116257813986612262fe15c1bb6dc9e39cc68693ac1fc5 \
     --hash=sha256:dcf0eb237dc47f062ef5925f98330af46f67e547cb587119c9ae78c17ae6c1d1
     # via schemathesis
+textual==6.1.0 \
+    --hash=sha256:a3f5e6710404fcdc6385385db894699282dccf2ad50103cebc677403c1baadd5 \
+    --hash=sha256:cc89826ca2146c645563259320ca4ddc75d183c77afb7d58acdd46849df9144d
+    # via mutmut
 time-machine==2.19.0 \
     --hash=sha256:714c40b2c90d1c57cc403382d5a9cf16e504cb525bfe9650095317da3c3d62b5 \
     --hash=sha256:7c5065a8b3f2bbb449422c66ef71d114d3f909c276a6469642ecfffb6a0fcd29
@@ -1381,6 +1550,7 @@ typing-extensions==4.15.0 \
     #   referencing
     #   schemathesis
     #   starlette
+    #   textual
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1 \
@@ -1389,6 +1559,10 @@ typing-inspection==0.4.1 \
     # via
     #   pydantic
     #   pydantic-settings
+uc-micro-py==1.0.3 \
+    --hash=sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a \
+    --hash=sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5
+    # via linkify-it-py
 uri-template==1.3.0 \
     --hash=sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7 \
     --hash=sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363


### PR DESCRIPTION
## Summary
- add `pytest-asyncio` to the development optional dependency set so async tests have their pytest plugin
- regenerate `requirements-dev.txt` and the combined `requirements.lock` to capture the new dependency pins

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9454c921c8329977e046bf92a5d4e