### PR TITLE
Tighten mypy configuration for core services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,16 @@ repos:
     hooks:
       - id: mypy
         args: ["--warn-unused-ignores", "--strict"]
-        files: ^src/factsynth_ultimate/
+        files: ^src/
+        additional_dependencies:
+          - fastapi==0.116.1
+          - starlette==0.45.3
+          - pydantic==2.11.7
+          - pydantic-settings==2.10.1
+          - redis==6.4.0
+          - types-redis
+          - prometheus-client==0.22.1
+          - httpx==0.28.1
   - repo: https://github.com/econchick/interrogate
     rev: 1.7.0
     hooks:

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,7 @@ ignore_missing_imports = True
 warn_unused_ignores = False
 warn_redundant_casts = False
 warn_return_any = False
-disallow_untyped_defs = False
+disallow_untyped_defs = True
 exclude = ^prompts/[^/]+/tests/
 disallow_subclassing_any = False
 
@@ -32,6 +32,28 @@ ignore_errors = True
 
 [mypy-factsynth_ultimate.api.*]
 ignore_errors = False
+disallow_incomplete_defs = True
+no_implicit_optional = True
+warn_return_any = True
+disallow_any_generics = True
 
 [mypy-factsynth_ultimate.services.*]
 ignore_errors = False
+disallow_incomplete_defs = True
+no_implicit_optional = True
+warn_return_any = True
+disallow_any_generics = True
+
+[mypy-factsynth_ultimate.core.*]
+ignore_errors = False
+disallow_incomplete_defs = True
+no_implicit_optional = True
+warn_return_any = True
+disallow_any_generics = True
+
+[mypy-factsynth_ultimate.validators.*]
+ignore_errors = False
+disallow_incomplete_defs = True
+no_implicit_optional = True
+warn_return_any = True
+disallow_any_generics = True

--- a/src/factsynth_ultimate/api/routers.py
+++ b/src/factsynth_ultimate/api/routers.py
@@ -162,7 +162,7 @@ def reload_allowed_hosts() -> None:
     """Clear the allowed hosts cache to reload settings."""
     get_allowed_hosts.cache_clear()
 
-api = APIRouter()
+api: APIRouter = APIRouter()
 api.include_router(generate_router)
 
 

--- a/src/factsynth_ultimate/api/v1/generate.py
+++ b/src/factsynth_ultimate/api/v1/generate.py
@@ -70,7 +70,7 @@ class PipelineNotReadyError(FactPipelineError):
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router: APIRouter = APIRouter()
 
 def _client_host(request: Request) -> str:
     """Best-effort retrieval of the requesting client's host."""

--- a/src/factsynth_ultimate/core/auth.py
+++ b/src/factsynth_ultimate/core/auth.py
@@ -11,6 +11,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
+from starlette.types import ASGIApp
 
 from ..i18n import choose_language, translate
 
@@ -22,7 +23,7 @@ class APIKeyAuthMiddleware(BaseHTTPMiddleware):
 
     def __init__(
         self,
-        app,
+        app: ASGIApp,
         api_keys: Iterable[str] | str,
         header_name: str = "x-api-key",
         skip: Iterable[str] = ("/v1/healthz", "/metrics"),

--- a/src/factsynth_ultimate/core/body_limit.py
+++ b/src/factsynth_ultimate/core/body_limit.py
@@ -8,6 +8,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
+from starlette.types import ASGIApp
 
 from ..i18n import choose_language, translate
 
@@ -15,7 +16,7 @@ from ..i18n import choose_language, translate
 class BodySizeLimitMiddleware(BaseHTTPMiddleware):
     """Reject requests whose body exceeds ``max_bytes``."""
 
-    def __init__(self, app, max_bytes: int = 2_000_000) -> None:
+    def __init__(self, app: ASGIApp, max_bytes: int = 2_000_000) -> None:
         """Configure the middleware with a byte limit."""
 
         super().__init__(app)

--- a/src/factsynth_ultimate/core/ip_allowlist.py
+++ b/src/factsynth_ultimate/core/ip_allowlist.py
@@ -10,6 +10,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
+from starlette.types import ASGIApp
 
 from ..i18n import choose_language, translate
 
@@ -21,7 +22,7 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
 
     def __init__(
         self,
-        app,
+        app: ASGIApp,
         cidrs: list[str] | None = None,
         skip: tuple[str, ...] = ("/v1/healthz", "/metrics"),
     ) -> None:

--- a/src/factsynth_ultimate/core/ratelimit.py
+++ b/src/factsynth_ultimate/core/ratelimit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hmac
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
+from typing import Any
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
@@ -24,7 +25,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self,
         app: ASGIApp,
         *,
-        redis: Redis,
+        redis: Redis[Any],
         per_key: int | None = None,
         per_ip: int | None = None,
         per_org: int | None = None,

--- a/src/factsynth_ultimate/core/request_id.py
+++ b/src/factsynth_ultimate/core/request_id.py
@@ -9,7 +9,7 @@ from typing import Awaitable, Callable
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
-
+from starlette.types import ASGIApp
 
 _request_id_ctx: ContextVar[str | None] = ContextVar("request_id", default=None)
 
@@ -23,7 +23,7 @@ def get_request_id() -> str | None:
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """Attach a unique ID to each request and response."""
 
-    def __init__(self, app, header_name: str = "x-request-id") -> None:
+    def __init__(self, app: ASGIApp, header_name: str = "x-request-id") -> None:
         """Configure the header name used for request IDs."""
 
         super().__init__(app)

--- a/src/factsynth_ultimate/core/security_headers.py
+++ b/src/factsynth_ultimate/core/security_headers.py
@@ -7,6 +7,7 @@ from typing import Awaitable, Callable
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
+from starlette.types import ASGIApp
 
 
 def _defaults(hsts: bool) -> dict[str, str]:
@@ -34,7 +35,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Apply headers that enforce a secure-by-default policy."""
 
     def __init__(
-        self, app, headers: dict[str, str] | None = None, hsts: bool = False
+        self, app: ASGIApp, headers: dict[str, str] | None = None, hsts: bool = False
     ) -> None:
         """Merge custom headers with defaults."""
 

--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -135,12 +135,12 @@ class Settings(BaseSettings):
             burst, sustain = value
             return RateQuota(int(burst), float(sustain))
         if isinstance(value, dict):
-            burst = value.get("burst")
-            sustain = value.get("sustain")
-            if burst is None or sustain is None:
+            burst_value = value.get("burst")
+            sustain_value = value.get("sustain")
+            if burst_value is None or sustain_value is None:
                 msg = "Rate mappings must define 'burst' and 'sustain'"
                 raise ValueError(msg)
-            return RateQuota(int(burst), float(sustain))
+            return RateQuota(int(burst_value), float(sustain_value))
         msg = f"Unsupported rate configuration: {type(value)!r}"
         raise TypeError(msg)
 


### PR DESCRIPTION
## Summary
* expand the mypy pre-commit hook to scan the entire `src/` tree and install FastAPI/Pydantic/Redis dependencies so strict checks run in CI. 【F:.pre-commit-config.yaml†L8-L22】
* enable `disallow_untyped_defs` and add stricter package-specific settings for the `factsynth_ultimate` API, services, core and validators. 【F:mypy.ini†L1-L59】
* annotate core middleware, rate limiting helpers and the source store with explicit ASGI and Redis typing to remove `Any` fallbacks picked up by the broader mypy coverage. 【F:src/factsynth_ultimate/core/auth.py†L5-L70】【F:src/factsynth_ultimate/core/body_limit.py†L5-L54】【F:src/factsynth_ultimate/core/ip_allowlist.py†L5-L80】【F:src/factsynth_ultimate/core/request_id.py†L5-L42】【F:src/factsynth_ultimate/core/security_headers.py†L5-L52】【F:src/factsynth_ultimate/core/rate_limit.py†L5-L201】【F:src/factsynth_ultimate/core/ratelimit.py†L5-L120】【F:src/factsynth_ultimate/core/settings.py†L120-L145】【F:src/factsynth_ultimate/core/source_store.py†L1-L155】
* type the FastAPI router singletons to avoid untyped decorator warnings now that mypy inspects the entire API surface. 【F:src/factsynth_ultimate/api/routers.py†L165-L198】【F:src/factsynth_ultimate/api/v1/generate.py†L71-L118】

## Testing
* ✅ `mypy --config-file mypy.ini src/factsynth_ultimate/api src/factsynth_ultimate/core src/factsynth_ultimate/services src/factsynth_ultimate/validators` 【3b0b80†L1-L2】
* ❌ `pre-commit run --all-files` *(ruff reports the existing lint backlog; pytest fails because fakeredis is absent in the hook environment)* 【5066ab†L1-L123】【834ca3†L1-L11】

------
https://chatgpt.com/codex/tasks/task_e_68c94e5d97e88329b53d69d5b4faee1a