### PR TITLE
Remove duplicate coverage artifact upload stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,14 +154,6 @@ jobs:
           pip install pytest pytest-cov hypothesis
           pytest --cov --cov-report=xml --ignore=tests/property --ignore=tests/test_tokenization.py
 
-      - name: Upload coverage artifact
-        if: hashFiles('tests/**','pyproject.toml','requirements.txt') != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: coverage-${{ matrix.python-version }}
-          path: coverage.xml
-          if-no-files-found: warn
-
       - name: Integration tests (Redis)
         if: hashFiles('tests/**','pyproject.toml','requirements.txt') != ''
         env:


### PR DESCRIPTION
## Summary
- drop the redundant coverage upload step from the build-test job
- ensure the remaining coverage upload runs only once per Python version with strict file checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c94e5f3df48329be05d3384b0c3cd2