### PR TITLE
Test OpenAPI contract via live client

### DIFF
--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -2,17 +2,28 @@ import pytest
 
 schemathesis = pytest.importorskip("schemathesis")
 
-OPENAPI_SPEC = {
-    "openapi": "3.1.0",
-    "info": {"title": "stub", "version": "0.1.0"},
-    "paths": {"/v1/score": {"post": {"responses": {"200": {"description": "OK"}}}}},
-}
+try:  # pragma: no cover - exercised in environments with newer Schemathesis
+    _from_dict = schemathesis.from_dict  # type: ignore[attr-defined]
+except AttributeError:  # pragma: no branch
+    _from_dict = schemathesis.openapi.from_dict
 
-schema = schemathesis.openapi.from_dict(OPENAPI_SPEC)
-schema.validate()
+pytestmark = [
+    pytest.mark.httpx_mock(assert_all_responses_were_requested=False),
+    pytest.mark.anyio,
+]
 
-pytestmark = pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
 
+async def test_openapi_schema_has_operations(client, base_headers) -> None:
+    response = await client.get("/openapi.json", headers=base_headers)
+    assert response.status_code == 200, response.text
 
-def test_openapi_schema_has_operations() -> None:
-    assert list(schema.get_all_operations())
+    raw_schema = response.json()
+    schema = _from_dict(raw_schema)
+    schema.validate()
+
+    operations = [result.ok() for result in schema.get_all_operations()]
+    assert operations, "OpenAPI contract must define operations"
+    assert any(
+        operation.path == "/v1/score" and operation.method.upper() == "POST"
+        for operation in operations
+    ), "Score endpoint is missing from the OpenAPI contract"


### PR DESCRIPTION
## Summary
- fetch the OpenAPI contract from the API client during the test instead of using a hard-coded schema
- validate the retrieved schema with Schemathesis and assert the expected /v1/score POST operation is present
- mark the contract test for anyio so it can await the async client

## Testing
- pytest --override-ini="addopts=-q -ra --cov --cov-report=term-missing --cov-report=xml --cov-fail-under=0" tests/test_openapi_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68c94e61337c83298e54c26bc9b77b2b