### PR TITLE
Simplify CI linting by relying on pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,30 +95,6 @@ jobs:
             echo "No ESLint config; skipping."
           fi
 
-      - name: Ruff
-        if: hashFiles('pyproject.toml','requirements.txt') != ''
-        run: |
-          pip install ruff
-          ruff check .
-
-      - name: Mypy
-        if: hashFiles('pyproject.toml','requirements.txt') != ''
-        run: |
-          pip install mypy
-          mypy .
-
-      - name: Bandit
-        if: hashFiles('pyproject.toml','requirements.txt') != ''
-        run: |
-          pip install bandit==1.7.9
-          bandit -r src/ --severity-level medium
-
-      - name: Interrogate
-        if: hashFiles('pyproject.toml','src/**/*.py') != ''
-        run: |
-          pip install interrogate
-          interrogate -c pyproject.toml src
-
       - name: Safety (PR, fail on high/critical)
         if: hashFiles('requirements.txt','requirements.lock','pyproject.toml') != ''
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ repos:
     rev: v0.6.3
     hooks:
       - id: ruff
-        args: ["--fix"]
-        files: "^(src|tests|scripts)/"
+        args: ["--fix", "--exit-non-zero-on-fix", "."]
+        pass_filenames: false
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0
     hooks:
       - id: mypy
-        args: ["--warn-unused-ignores", "--strict"]
-        files: ^src/factsynth_ultimate/
+        args: ["--warn-unused-ignores", "--strict", "."]
+        pass_filenames: false
   - repo: https://github.com/econchick/interrogate
     rev: 1.7.0
     hooks:


### PR DESCRIPTION
## Summary
- remove standalone Ruff, Mypy, Bandit, and Interrogate steps from the CI workflow so the job depends on the pre-commit action
- update the pre-commit configuration so Ruff and Mypy run across the full repository when the action executes

## Testing
- pre-commit run --all-files *(fails: existing Ruff violations, Mypy type errors, and pytest missing the `fakeredis` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c94e60c17c8329814f13432d00b06b