### PR TITLE
Add Redis health check fallback with recovery

### DIFF
--- a/src/factsynth_ultimate/services/evaluator.py
+++ b/src/factsynth_ultimate/services/evaluator.py
@@ -28,14 +28,21 @@ def _load_retriever(name: str) -> Retriever:
         )
     except TypeError:
         eps = metadata.entry_points()
-        get_group = getattr(eps, "get", None)
-        if callable(get_group):
+        select = getattr(eps, "select", None)
+        if callable(select):
             candidates = cast(
                 Iterable[EntryPoint],
-                get_group("factsynth_ultimate.retrievers", ()),
+                select(group="factsynth_ultimate.retrievers"),
             )
         else:
-            candidates = ()
+            get_group = getattr(eps, "get", None)
+            if callable(get_group):
+                candidates = cast(
+                    Iterable[EntryPoint],
+                    get_group("factsynth_ultimate.retrievers", ()),
+                )
+            else:
+                candidates = ()
     for ep in candidates:
         if ep.name != name:
             continue

--- a/tests/middleware/test_rate_limit.py
+++ b/tests/middleware/test_rate_limit.py
@@ -45,6 +45,9 @@ class FakeRedis:
     async def expire(self, key: str, ttl: int) -> None:
         self._expiry[key] = self._now() + ttl
 
+    async def ping(self) -> bool:  # pragma: no cover - trivial behaviour
+        return True
+
     def keys(self) -> set[str]:
         for key in list(self._data):
             self._maybe_expire(key)
@@ -90,6 +93,7 @@ def _middleware(redis: FakeRedis, **kwargs) -> RateLimitMiddleware:
         lambda scope, receive, send: None,
         redis=redis,
         **kwargs,
+        health_check_interval=0.0,
     )
 
 

--- a/tests/store/test_fallback.py
+++ b/tests/store/test_fallback.py
@@ -31,6 +31,7 @@ class FlakyRedis:
     def __init__(self, failures: int, delegate: MemoryStore) -> None:
         self._failures = failures
         self._delegate = delegate
+        self.calls: list[tuple[str, str]] = []
 
     def _maybe_fail(self) -> None:
         if self._failures > 0:
@@ -39,15 +40,58 @@ class FlakyRedis:
 
     async def hgetall(self, key: str):
         self._maybe_fail()
+        self.calls.append(("hgetall", key))
         return await self._delegate.hgetall(key)
 
     async def hset(self, key: str, mapping):  # noqa: ANN001
         self._maybe_fail()
+        self.calls.append(("hset", key))
         return await self._delegate.hset(key, mapping)
 
     async def expire(self, key: str, ttl: int):
         self._maybe_fail()
+        self.calls.append(("expire", key))
         return await self._delegate.expire(key, ttl)
+
+    async def ping(self) -> bool:  # pragma: no cover - trivial behaviour
+        return True
+
+
+class OfflineRedis:
+    """Redis stub whose health check always fails."""
+
+    def __init__(self, delegate: MemoryStore) -> None:
+        self._delegate = delegate
+        self.calls: list[tuple[str, str]] = []
+
+    async def ping(self) -> bool:
+        raise RedisError("offline")
+
+    async def hgetall(self, key: str):
+        self.calls.append(("hgetall", key))
+        return await self._delegate.hgetall(key)
+
+    async def hset(self, key: str, mapping):  # noqa: ANN001
+        self.calls.append(("hset", key))
+        return await self._delegate.hset(key, mapping)
+
+    async def expire(self, key: str, ttl: int):
+        self.calls.append(("expire", key))
+        return await self._delegate.expire(key, ttl)
+
+
+class RecoveringRedis(OfflineRedis):
+    """Redis stub that eventually reports healthy again."""
+
+    def __init__(self, failures: int, delegate: MemoryStore) -> None:
+        super().__init__(delegate)
+        self._remaining_failures = failures
+
+    async def ping(self) -> bool:
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            raise RedisError("offline")
+        return True
 
 
 class BrokenRedis:
@@ -63,7 +107,7 @@ def clock(monkeypatch):
     return clk
 
 
-def _middleware(redis, memory_store, fallback_timeout: float = 10.0):
+def _middleware(redis, memory_store, fallback_timeout: float = 10.0, **kwargs):
     quota = rate_limit.RateQuota(5, 1.0)
     return rate_limit.RateLimitMiddleware(
         lambda scope, receive, send: None,
@@ -74,6 +118,7 @@ def _middleware(redis, memory_store, fallback_timeout: float = 10.0):
         ttl=60,
         memory_store=memory_store,
         fallback_timeout=fallback_timeout,
+        **kwargs,
     )
 
 
@@ -82,7 +127,7 @@ async def test_switches_to_memory_on_failure(clock):
     memory_backend = MemoryStore(now=clock.monotonic)
     redis_backend = MemoryStore(now=clock.monotonic)
     redis = FlakyRedis(1, redis_backend)
-    middleware = _middleware(redis, memory_backend)
+    middleware = _middleware(redis, memory_backend, health_check_interval=0.0)
 
     allowed, _ = await middleware._take("bucket", middleware.api_quota)
     assert allowed is True
@@ -101,7 +146,12 @@ async def test_recovers_after_timeout(clock):
     memory_backend = MemoryStore(now=clock.monotonic)
     redis_backend = MemoryStore(now=clock.monotonic)
     redis = FlakyRedis(1, redis_backend)
-    middleware = _middleware(redis, memory_backend, fallback_timeout=5.0)
+    middleware = _middleware(
+        redis,
+        memory_backend,
+        fallback_timeout=5.0,
+        health_check_interval=0.0,
+    )
 
     await middleware._take("bucket", middleware.api_quota)
     assert middleware._using_memory is True
@@ -118,3 +168,56 @@ async def test_recovers_after_timeout(clock):
 async def test_check_health_reports_failure():
     client = BrokenRedis()
     assert await check_health(client) is False
+
+
+@pytest.mark.anyio
+async def test_health_check_triggers_fallback(clock, caplog):
+    memory_backend = MemoryStore(now=clock.monotonic)
+    redis_backend = MemoryStore(now=clock.monotonic)
+    redis = OfflineRedis(redis_backend)
+    middleware = _middleware(
+        redis,
+        memory_backend,
+        fallback_timeout=5.0,
+        health_check_interval=2.0,
+    )
+
+    with caplog.at_level("WARNING"):
+        allowed, _ = await middleware._take("bucket", middleware.api_quota)
+
+    assert allowed is True
+    assert middleware._using_memory is True
+    assert redis.calls == []
+    assert any("Redis backend unavailable" in rec.message for rec in caplog.records)
+    assert await memory_backend.hgetall("bucket")
+    assert await redis_backend.hgetall("bucket") == {}
+
+
+@pytest.mark.anyio
+async def test_health_check_recovers(clock):
+    memory_backend = MemoryStore(now=clock.monotonic)
+    redis_backend = MemoryStore(now=clock.monotonic)
+    redis = RecoveringRedis(1, redis_backend)
+    middleware = _middleware(
+        redis,
+        memory_backend,
+        fallback_timeout=30.0,
+        health_check_interval=5.0,
+    )
+
+    await middleware._take("bucket", middleware.api_quota)
+    assert middleware._using_memory is True
+    assert redis.calls == []
+
+    clock.advance(2.0)
+    await middleware._take("bucket", middleware.api_quota)
+    assert middleware._using_memory is True
+    assert redis.calls == []
+
+    clock.advance(10.0)
+    allowed, _ = await middleware._take("bucket", middleware.api_quota)
+    assert allowed is True
+    assert middleware._using_memory is False
+    assert any(call[0] == "hgetall" for call in redis.calls)
+    redis_data = await redis_backend.hgetall("bucket")
+    assert "tokens" in redis_data


### PR DESCRIPTION
## Summary
- add proactive Redis health checks and automated recovery to the rate limit middleware
- exercise fallback, health check, and recovery flows with new in-memory Redis stubs
- support modern importlib metadata entry points when loading retrievers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96aec17948329bee2f6c0ed5982ad