### PR TITLE
Add API and CLI management for callback allowlist

### DIFF
--- a/src/factsynth_ultimate/cli.py
+++ b/src/factsynth_ultimate/cli.py
@@ -7,7 +7,12 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
-from factsynth_ultimate.config import ConfigError, add_callback_host
+from factsynth_ultimate.config import (
+    ConfigError,
+    add_callback_host,
+    load_config,
+    remove_callback_host,
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -29,6 +34,17 @@ def _build_parser() -> argparse.ArgumentParser:
     allow_parser = callbacks_sub.add_parser("allow", help="Allow callbacks to the specified host")
     allow_parser.add_argument("host", help="Hostname to add to the callback allowlist")
     allow_parser.set_defaults(func=_callbacks_allow)
+
+    remove_parser = callbacks_sub.add_parser(
+        "remove", help="Remove callbacks to the specified host"
+    )
+    remove_parser.add_argument("host", help="Hostname to remove from the callback allowlist")
+    remove_parser.set_defaults(func=_callbacks_remove)
+
+    list_parser = callbacks_sub.add_parser(
+        "list", help="Show the configured callback allowlist"
+    )
+    list_parser.set_defaults(func=_callbacks_list)
 
     return parser
 
@@ -52,6 +68,45 @@ def _callbacks_allow(args: argparse.Namespace) -> int:
 
     allowlist = ", ".join(config.CALLBACK_URL_ALLOWED_HOSTS) or "<empty>"
     print(f"Callback host '{normalized}' allowed.")
+    print(f"Current callback allowlist: {allowlist}")
+    return 0
+
+
+def _callbacks_remove(args: argparse.Namespace) -> int:
+    host_raw: str = args.host.strip()
+    if not host_raw:
+        print("error: host must not be empty", file=sys.stderr)
+        return 2
+
+    normalized = host_raw.lower()
+    cfg_path: Path | None = args.config
+    try:
+        config = remove_callback_host(normalized, path=cfg_path)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:  # pragma: no cover - filesystem failures
+        print(f"error: failed to update configuration: {exc}", file=sys.stderr)
+        return 2
+
+    allowlist = ", ".join(config.CALLBACK_URL_ALLOWED_HOSTS) or "<empty>"
+    print(f"Callback host '{normalized}' removed.")
+    print(f"Current callback allowlist: {allowlist}")
+    return 0
+
+
+def _callbacks_list(args: argparse.Namespace) -> int:
+    cfg_path: Path | None = args.config
+    try:
+        config = load_config(cfg_path)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:  # pragma: no cover - filesystem failures
+        print(f"error: failed to read configuration: {exc}", file=sys.stderr)
+        return 2
+
+    allowlist = ", ".join(config.CALLBACK_URL_ALLOWED_HOSTS) or "<empty>"
     print(f"Current callback allowlist: {allowlist}")
     return 0
 

--- a/src/factsynth_ultimate/config.py
+++ b/src/factsynth_ultimate/config.py
@@ -85,6 +85,32 @@ def add_callback_host(host: str, path: Path | None = None) -> Config:
     return config
 
 
+def remove_callback_host(host: str, path: Path | None = None) -> Config:
+    """Remove ``host`` from the callback allowlist stored at ``path``."""
+
+    config = load_config(path)
+    if not config.CALLBACK_URL_ALLOWED_HOSTS:
+        return config
+
+    targets = set(_normalize_hosts([host]))
+    if not targets:
+        return config
+
+    remaining = [item for item in config.CALLBACK_URL_ALLOWED_HOSTS if item not in targets]
+    config.CALLBACK_URL_ALLOWED_HOSTS = _normalize_hosts(remaining)
+    save_config(config, path)
+    return config
+
+
+def set_callback_hosts(hosts: Iterable[Any], path: Path | None = None) -> Config:
+    """Replace the callback allowlist with ``hosts`` at ``path``."""
+
+    config = load_config(path)
+    config.CALLBACK_URL_ALLOWED_HOSTS = _normalize_hosts(hosts)
+    save_config(config, path)
+    return config
+
+
 def _normalize_hosts(hosts: Iterable[Any]) -> list[str]:
     """Return a sorted, deduplicated list of normalised hosts."""
 
@@ -106,6 +132,8 @@ __all__ = [
     "Config",
     "ConfigError",
     "add_callback_host",
+    "remove_callback_host",
+    "set_callback_hosts",
     "config_path",
     "load_config",
     "save_config",

--- a/src/factsynth_ultimate/schemas/callbacks.py
+++ b/src/factsynth_ultimate/schemas/callbacks.py
@@ -1,0 +1,37 @@
+"""Schemas for managing callback allowlists via API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class CallbackHostRequest(BaseModel):
+    """Request payload for adding a single callback host."""
+
+    host: str = Field(description="Hostname to allow for callbacks")
+
+    @field_validator("host")
+    @classmethod
+    def _normalize(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("host must not be empty")
+        return normalized
+
+
+class CallbackAllowlistSetRequest(BaseModel):
+    """Request payload for replacing the callback allowlist."""
+
+    hosts: list[str] = Field(default_factory=list, description="List of allowed callback hosts")
+
+    @field_validator("hosts")
+    @classmethod
+    def _normalize_hosts(cls, hosts: list[str]) -> list[str]:
+        return [host.strip().lower() for host in hosts if host and host.strip()]
+
+
+class CallbackAllowlistResponse(BaseModel):
+    """Response payload describing the configured callback allowlist."""
+
+    hosts: list[str]
+

--- a/tests/callbacks/test_allowlist.py
+++ b/tests/callbacks/test_allowlist.py
@@ -1,7 +1,11 @@
+import logging
+from http import HTTPStatus
+
 import pytest
 
 from factsynth_ultimate.cli import main as fsctl_main
 from factsynth_ultimate.config import Config, load_config, save_config
+from factsynth_ultimate.api.routers import get_allowed_hosts, reload_allowed_hosts
 from factsynth_ultimate.validators.callback import validate_callback_url
 
 
@@ -27,6 +31,30 @@ def test_cli_callbacks_allow_deduplicates(tmp_path):
     assert cfg.CALLBACK_URL_ALLOWED_HOSTS == ["example.com"]
 
 
+def test_cli_callbacks_remove_updates_allowlist(tmp_path):
+    config_file = tmp_path / "config.json"
+    fsctl_main(["--config", str(config_file), "callbacks", "allow", "example.com"])
+
+    exit_code = fsctl_main(["--config", str(config_file), "callbacks", "remove", "example.com"])
+
+    assert exit_code == 0
+    cfg = load_config(config_file)
+    assert cfg.CALLBACK_URL_ALLOWED_HOSTS == []
+
+
+def test_cli_callbacks_list_shows_current_allowlist(tmp_path, capsys):
+    config_file = tmp_path / "config.json"
+
+    fsctl_main(["--config", str(config_file), "callbacks", "list"])
+    output = capsys.readouterr().out
+    assert "<empty>" in output
+
+    fsctl_main(["--config", str(config_file), "callbacks", "allow", "example.com"])
+    fsctl_main(["--config", str(config_file), "callbacks", "list"])
+    output = capsys.readouterr().out
+    assert "example.com" in output
+
+
 @pytest.mark.parametrize(
     ("url", "allowed", "expect_problem", "expected_reason"),
     [
@@ -35,12 +63,63 @@ def test_cli_callbacks_allow_deduplicates(tmp_path):
         ("https://example.com/cb", [], True, "allowlist_empty"),
     ],
 )
-def test_validate_callback_url_allowlist(url, allowed, expect_problem, expected_reason):
+def test_validate_callback_url_allowlist(url, allowed, expect_problem, expected_reason, caplog):
+    caplog.set_level(logging.WARNING)
+    caplog.clear()
     problem = validate_callback_url(url, allowed)
     assert (problem is not None) is expect_problem
     if problem:
         assert "callback" in problem.detail.lower()
         assert problem.extras["reason"] == expected_reason
+        records = [record for record in caplog.records if record.name == "factsynth_ultimate.validators.callback"]
+        assert records, "expected validation to emit log record"
+        logged = records[-1].problem_details
+        assert logged["extras"]["reason"] == expected_reason
+    else:
+        assert not [
+            record
+            for record in caplog.records
+            if record.name == "factsynth_ultimate.validators.callback"
+        ]
+
+
+@pytest.mark.anyio
+async def test_api_callbacks_allowlist_crud(client, base_headers, tmp_path, monkeypatch):
+    config_file = tmp_path / "config.json"
+    monkeypatch.setenv("FACTSYNTH_CONFIG_PATH", str(config_file))
+    reload_allowed_hosts()
+    try:
+        response = await client.get("/v1/callbacks/allowlist", headers=base_headers)
+        assert response.status_code == HTTPStatus.OK
+        assert response.json() == {"hosts": []}
+
+        response = await client.post(
+            "/v1/callbacks/allowlist",
+            headers=base_headers,
+            json={"host": "Example.com"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert response.json() == {"hosts": ["example.com"]}
+
+        response = await client.put(
+            "/v1/callbacks/allowlist",
+            headers=base_headers,
+            json={"hosts": ["Another.com", "Example.com"]},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert response.json() == {"hosts": ["another.com", "example.com"]}
+
+        response = await client.delete(
+            "/v1/callbacks/allowlist/example.com", headers=base_headers
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert response.json() == {"hosts": ["another.com"]}
+
+        cfg = load_config(config_file)
+        assert cfg.CALLBACK_URL_ALLOWED_HOSTS == ["another.com"]
+        assert list(get_allowed_hosts()) == ["another.com"]
+    finally:
+        reload_allowed_hosts()
 
 
 def test_settings_respects_saved_allowlist(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add CLI list/remove commands for callback hosts and persist configuration updates
- expose REST endpoints for managing the callback allowlist with new schemas
- log callback validation rejections with structured ProblemDetails and extend tests

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/callbacks/test_allowlist.py
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/test_validate_callback_url.py

------
https://chatgpt.com/codex/tasks/task_e_68c96aef87f88329879d3e74da35b972