### PR TITLE
Enhance websocket auth and limits

### DIFF
--- a/src/factsynth_ultimate/core/settings.py
+++ b/src/factsynth_ultimate/core/settings.py
@@ -70,6 +70,9 @@ class Settings(BaseSettings):
     rates_org: RateQuota = Field(
         default_factory=lambda: RateQuota(60, 1.0), alias="RATES_ORG"
     )
+    ws_max_sessions_per_key: int = Field(
+        default=0, alias="WS_MAX_SESSIONS_PER_KEY", ge=0
+    )
     token_delay: float = Field(default=0.002, ge=0, alias="TOKEN_DELAY")
     health_tcp_checks: Annotated[list[str], NoDecode] = Field(
         default_factory=list, alias="HEALTH_TCP_CHECKS"

--- a/tests/auth/test_ws_auth.py
+++ b/tests/auth/test_ws_auth.py
@@ -11,13 +11,22 @@ def _reset_registry():
 
 
 def test_authenticate_ws_success():
-    user = ws.WebSocketUser(api_key="alpha", organization="team", status="active")
+    user = ws.WebSocketUser(
+        api_key="alpha",
+        user={"id": "user-alpha", "email": "alpha@example.com"},
+        organization={"slug": "team", "name": "Team"},
+        status="active",
+    )
     ws.set_ws_registry({user.api_key: user})
 
     authenticated = ws.authenticate_ws("alpha")
 
     assert authenticated is user
-    assert authenticated.organization == "team"
+    assert authenticated.user["email"] == "alpha@example.com"
+    assert authenticated.organization["slug"] == "team"
+    assert authenticated.organization_name == "Team"
+    assert authenticated.organization_slug == "team"
+    assert authenticated.user_id == "user-alpha"
 
 
 def test_authenticate_ws_missing_key():
@@ -39,7 +48,12 @@ def test_authenticate_ws_unknown_key():
 
 
 def test_authenticate_ws_requires_organization():
-    user = ws.WebSocketUser(api_key="beta", organization="", status="active")
+    user = ws.WebSocketUser(
+        api_key="beta",
+        user={"id": "user-beta"},
+        organization={},
+        status="active",
+    )
     ws.set_ws_registry({user.api_key: user})
 
     with pytest.raises(ws.WebSocketAuthError) as excinfo:
@@ -49,7 +63,12 @@ def test_authenticate_ws_requires_organization():
 
 
 def test_authenticate_ws_requires_active_status():
-    user = ws.WebSocketUser(api_key="gamma", organization="org", status="disabled")
+    user = ws.WebSocketUser(
+        api_key="gamma",
+        user={"id": "user-gamma"},
+        organization={"slug": "org"},
+        status="disabled",
+    )
     ws.set_ws_registry({user.api_key: user})
 
     with pytest.raises(ws.WebSocketAuthError) as excinfo:
@@ -58,8 +77,28 @@ def test_authenticate_ws_requires_active_status():
     assert excinfo.value.code == 4429
 
 
+def test_authenticate_ws_requires_user_payload():
+    user = ws.WebSocketUser(
+        api_key="epsilon",
+        user={},
+        organization={"slug": "ops"},
+        status="active",
+    )
+    ws.set_ws_registry({user.api_key: user})
+
+    with pytest.raises(ws.WebSocketAuthError) as excinfo:
+        ws.authenticate_ws("epsilon")
+
+    assert excinfo.value.code == 4401
+
+
 def test_authenticate_ws_case_insensitive_lookup():
-    user = ws.WebSocketUser(api_key="DeltaKey", organization="org", status="active")
+    user = ws.WebSocketUser(
+        api_key="DeltaKey",
+        user={"id": "user-delta"},
+        organization={"slug": "org"},
+        status="active",
+    )
     ws.set_ws_registry({user.api_key: user})
 
     authenticated = ws.authenticate_ws("deltakey")


### PR DESCRIPTION
## Summary
- enrich websocket authentication data to include structured user and organization payloads with additional validation
- add per-session rate limiting, api-key connection tracking, and detailed logging for websocket lifecycle events
- introduce configurable per-key session caps and expand unit tests covering authentication, rate limiting, and connection limits

## Testing
- `pytest tests/auth/test_ws_auth.py tests/stream/test_ws_limits.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c96af071548329bf03dd3236333a46