### PR TITLE
Add OpenTelemetry tracing configuration and span smoke tests

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Welcome to the FactSynth documentation site built with MkDocs and the Material t
 
 - [Production Runbook](prod-runbook.md)
 - [UI Deployment](ui-deployment.md)
+- [Tracing and Observability](tracing.md)
 - [Prompt Pack](PromptPack.md)
 - [Incubation Co-Dev UA](INCUBATION_CO_DEV_UA.md)
 - [FactSynth Lock](FACTSYNTH_LOCK.md)

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,56 @@
+# Tracing and Observability
+
+FactSynth Ultimate emits OpenTelemetry traces for critical API paths. This page
+describes how to enable exporters, what spans are produced, and how to run the
+smoke test that verifies the instrumentation.
+
+## Exporter configuration
+
+Tracing is disabled by default. Enable it by setting the
+`FACTSYNTH_TRACE_EXPORTER` environment variable to either `otlp` or `jaeger`
+before starting the API server.
+
+```bash
+# OTLP over HTTP or gRPC depending on the installed exporter package
+export FACTSYNTH_TRACE_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector:4318"
+
+# Optional service name override (defaults to ``factsynth-ultimate``)
+export FACTSYNTH_TRACE_SERVICE_NAME=factsynth-ultimate-prod
+
+# Jaeger agent example
+export FACTSYNTH_TRACE_EXPORTER=jaeger
+export OTEL_EXPORTER_JAEGER_AGENT_HOST=jaeger-agent
+export OTEL_EXPORTER_JAEGER_AGENT_PORT=6831
+```
+
+The tracer provider automatically picks up the deployment environment from the
+`ENV` variable when it is present. If the required exporter package is missing,
+FactSynth logs a warning and continues to run without tracing.
+
+## Manual spans
+
+The application emits explicit spans for the most critical code paths:
+
+- `api.generate` wraps the synchronous fact generation endpoint.
+- `api.stream` records Server-Sent Events streaming, including chunk counters.
+- `callback.post` tracks background callback delivery attempts.
+
+Each span annotates the current request identifier (if available) and records
+retry attempts, chunk sizes, and success/failure metadata. When an error occurs,
+the span records the exception and the HTTP status code that is returned to the
+client. All error responses now include the active `trace_id` to simplify
+cross-referencing log messages with trace exports.
+
+## Smoke test
+
+Run the dedicated test module to validate that spans are produced and enriched
+as expected:
+
+```bash
+pytest tests/test_tracing_spans.py
+```
+
+The smoke test exercises the `/v1/generate` endpoint, the SSE streaming helper,
+and the callback retry loop with a fake tracer. It asserts that spans are
+created and that trace identifiers surface in problem responses.

--- a/src/factsynth_ultimate/core/problem_details.py
+++ b/src/factsynth_ultimate/core/problem_details.py
@@ -8,6 +8,8 @@ from typing import Any
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from .tracing import current_trace_id
+
 
 class ProblemDetails(BaseModel):
     """Representation of an RFC 9457 problem response."""
@@ -18,6 +20,7 @@ class ProblemDetails(BaseModel):
     type: str = "about:blank"
     instance: str | None = None
     extras: dict[str, Any] | None = None
+    trace_id: str | None = None
 
     def to_response(self) -> JSONResponse:
         """Return a :class:`JSONResponse` configured for problem+json."""
@@ -26,6 +29,9 @@ class ProblemDetails(BaseModel):
         extras = payload.pop("extras", None)
         if extras:
             payload.update(extras)
+        trace_id = payload.get("trace_id") or current_trace_id()
+        if trace_id:
+            payload["trace_id"] = trace_id
         return JSONResponse(
             payload,
             status_code=self.status,

--- a/src/factsynth_ultimate/core/tracing.py
+++ b/src/factsynth_ultimate/core/tracing.py
@@ -1,26 +1,248 @@
-"""Optional OpenTelemetry instrumentation."""
+"""OpenTelemetry helpers and instrumentation glue."""
 
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import suppress
+from importlib import import_module
+from typing import Any, Callable
 
 from fastapi import FastAPI
 
 log = logging.getLogger("factsynth.telemetry")
 
-try:
-    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+try:  # pragma: no cover - optional dependency
+    from opentelemetry import trace as _otel_trace  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    _otel_trace = None
+
+try:  # pragma: no cover - optional dependency
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
     FastAPIInstrumentor = None
 
 
+_EXPORTER_ENV = "FACTSYNTH_TRACE_EXPORTER"
+_SERVICE_NAME_ENV = "FACTSYNTH_TRACE_SERVICE_NAME"
+_DEFAULT_SERVICE_NAME = "factsynth-ultimate"
+
+
+class _NoOpSpan:
+    """Fallback span implementation when OpenTelemetry is unavailable."""
+
+    def __enter__(self) -> "_NoOpSpan":  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, *exc: object) -> bool:  # pragma: no cover - trivial
+        return False
+
+    # The real span API exposes these methods; we provide graceful no-ops.
+    def set_attribute(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def add_event(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def record_exception(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def set_status(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+
+class _NoOpTracer:
+    """Tracer shim yielding :class:`_NoOpSpan` instances."""
+
+    def start_as_current_span(self, *_args: object, **_kwargs: object) -> _NoOpSpan:
+        return _NoOpSpan()
+
+
+_tracer_factory: Callable[[str], Any] | None = None
+_provider_configured = False
+
+
+def _default_tracer_factory(component: str) -> Any:
+    if _otel_trace is None:  # pragma: no cover - optional dependency path
+        return _NoOpTracer()
+    return _otel_trace.get_tracer(component)
+
+
+def set_tracer_factory(factory: Callable[[str], Any]) -> None:
+    """Override the tracer factory (intended for tests)."""
+
+    global _tracer_factory
+    _tracer_factory = factory
+
+
+def get_tracer(component: str) -> Any:
+    """Return a tracer object for ``component``.
+
+    The returned object follows the OpenTelemetry ``Tracer`` protocol. If
+    OpenTelemetry is unavailable, a lightweight no-op tracer is returned so
+    callers can safely use ``start_as_current_span``.
+    """
+
+    factory = _tracer_factory or _default_tracer_factory
+    try:
+        return factory(component)
+    except Exception:  # pragma: no cover - defensive
+        log.debug("failed to acquire tracer", exc_info=True)
+        return _NoOpTracer()
+
+
+def current_trace_id() -> str | None:
+    """Return the current trace identifier, if available."""
+
+    if _otel_trace is None:  # pragma: no cover - optional dependency path
+        return None
+    span = _otel_trace.get_current_span()
+    if span is None:
+        return None
+    ctx = getattr(span, "get_span_context", lambda: None)()
+    trace_id = getattr(ctx, "trace_id", 0)
+    is_valid = getattr(ctx, "is_valid", lambda: False)()
+    if not is_valid:
+        return None
+    return f"{trace_id:032x}"
+
+
+def _batch_span_processor() -> Any | None:
+    try:
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        return None
+    return BatchSpanProcessor
+
+
+def _resource_factory() -> tuple[Any | None, str]:
+    try:
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        return None, "service.name"
+    return Resource, SERVICE_NAME
+
+
+def _load_otlp_exporter() -> Any | None:
+    modules = (
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter",
+    )
+    for module_path in modules:
+        with suppress(ImportError, AttributeError):
+            module = import_module(module_path)
+            exporter_cls = getattr(module, "OTLPSpanExporter")
+            return exporter_cls()  # type: ignore[no-any-return]
+    log.warning("otel_exporter_unavailable", extra={"exporter": "otlp"})
+    return None
+
+
+def _load_jaeger_exporter() -> Any | None:
+    with suppress(ImportError):
+        from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # type: ignore
+    if "JaegerExporter" not in locals():  # pragma: no cover - optional dependency
+        log.warning("otel_exporter_unavailable", extra={"exporter": "jaeger"})
+        return None
+
+    kwargs: dict[str, Any] = {}
+    endpoint = os.getenv("OTEL_EXPORTER_JAEGER_ENDPOINT")
+    host = os.getenv("OTEL_EXPORTER_JAEGER_AGENT_HOST")
+    port = os.getenv("OTEL_EXPORTER_JAEGER_AGENT_PORT")
+
+    if endpoint:
+        kwargs["collector_endpoint"] = endpoint
+        if username := os.getenv("OTEL_EXPORTER_JAEGER_USER"):
+            kwargs["username"] = username
+        if password := os.getenv("OTEL_EXPORTER_JAEGER_PASSWORD"):
+            kwargs["password"] = password
+        if certificate := os.getenv("OTEL_EXPORTER_JAEGER_CERTIFICATE"):
+            kwargs["certificate"] = certificate
+        insecure_raw = os.getenv("OTEL_EXPORTER_JAEGER_INSECURE")
+        if insecure_raw:
+            kwargs["insecure"] = insecure_raw.lower() in {"1", "true", "yes", "on"}
+    else:
+        if host:
+            kwargs["agent_host_name"] = host
+        if port:
+            with suppress(ValueError):
+                kwargs["agent_port"] = int(port)
+
+    return JaegerExporter(**kwargs)
+
+
+def _select_exporter() -> tuple[Any | None, str | None]:
+    name = os.getenv(_EXPORTER_ENV, "").strip().lower()
+    if not name:
+        log.info("otel_exporter_skipped: not configured")
+        return None, None
+    if name == "otlp":
+        return _load_otlp_exporter(), name
+    if name == "jaeger":
+        return _load_jaeger_exporter(), name
+    log.warning("otel_exporter_unknown", extra={"exporter": name})
+    return None, name
+
+
+def _configure_provider() -> None:
+    global _provider_configured
+    if _provider_configured:
+        return
+    if _otel_trace is None:  # pragma: no cover - optional dependency path
+        log.debug("OpenTelemetry trace API unavailable; skipping provider setup")
+        return
+
+    exporter, exporter_name = _select_exporter()
+    if exporter is None:
+        if exporter_name:
+            log.warning("otel_exporter_not_initialized", extra={"exporter": exporter_name})
+        return
+
+    BatchSpanProcessor = _batch_span_processor()
+    resource_factory, service_name_attr = _resource_factory()
+    try:
+        from opentelemetry.sdk.trace import TracerProvider  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        log.warning("otel_sdk_missing")
+        return
+    if BatchSpanProcessor is None or resource_factory is None:
+        log.warning("otel_sdk_incomplete")
+        return
+
+    service_name = (
+        os.getenv("OTEL_SERVICE_NAME")
+        or os.getenv(_SERVICE_NAME_ENV)
+        or _DEFAULT_SERVICE_NAME
+    )
+    resource_attributes = {service_name_attr: service_name}
+    if env := os.getenv("ENV"):
+        resource_attributes["deployment.environment"] = env
+
+    provider = TracerProvider(resource=resource_factory.create(resource_attributes))
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    _otel_trace.set_tracer_provider(provider)
+    _provider_configured = True
+    log.info("otel_exporter_configured", extra={"exporter": exporter_name, "service": service_name})
+
+
 def try_enable_otel(app: FastAPI) -> None:
-    """Instrument *app* with OpenTelemetry if available."""
+    """Instrument *app* with OpenTelemetry if the dependency is available."""
 
     if FastAPIInstrumentor is None:
         log.info("otel_disabled: missing dependency")
         return
+
+    _configure_provider()
+
     with suppress(Exception):
         FastAPIInstrumentor.instrument_app(app)
         log.info("otel_enabled")
+
+
+__all__ = [
+    "FastAPIInstrumentor",
+    "current_trace_id",
+    "get_tracer",
+    "set_tracer_factory",
+    "try_enable_otel",
+]
+

--- a/tests/test_tracing_spans.py
+++ b/tests/test_tracing_spans.py
@@ -1,0 +1,171 @@
+"""Smoke tests covering manual tracing spans."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from factsynth_ultimate.api.routers import _post_callback, _sse_stream
+from factsynth_ultimate.api.v1.generate import get_fact_pipeline
+from factsynth_ultimate.app import create_app
+from factsynth_ultimate.core import tracing
+from factsynth_ultimate.schemas.requests import ScoreReq
+
+
+class FakeSpan:
+    def __init__(self, name: str, tracer: "FakeTracer", trace_id: str) -> None:
+        self.name = name
+        self.tracer = tracer
+        self.trace_id = trace_id
+        self.attributes: dict[str, Any] = {}
+        self.events: list[tuple[str, dict[str, Any]]] = []
+        self.exceptions: list[BaseException] = []
+
+    def __enter__(self) -> "FakeSpan":
+        self.tracer.spans.append(self)
+        self.tracer.current_trace_id = self.trace_id
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any) -> bool:
+        self.tracer.current_trace_id = None
+        return False
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
+
+    def add_event(self, name: str, attributes: dict[str, Any] | None = None) -> None:
+        self.events.append((name, attributes or {}))
+
+    def record_exception(self, exc: BaseException) -> None:
+        self.exceptions.append(exc)
+
+
+class FakeTracer:
+    def __init__(self) -> None:
+        self.spans: list[FakeSpan] = []
+        self._counter = 0
+        self.current_trace_id: str | None = None
+
+    def start_as_current_span(self, name: str, **_: Any) -> FakeSpan:
+        self._counter += 1
+        trace_id = f"{self._counter:032x}"
+        return FakeSpan(name, self, trace_id)
+
+
+@pytest.fixture()
+def fake_tracer(monkeypatch: pytest.MonkeyPatch) -> FakeTracer:
+    tracer = FakeTracer()
+    monkeypatch.setattr(tracing, "get_tracer", lambda _: tracer)
+    monkeypatch.setattr(tracing, "current_trace_id", lambda: tracer.current_trace_id)
+    monkeypatch.setattr(
+        "factsynth_ultimate.core.problem_details.current_trace_id",
+        lambda: tracer.current_trace_id,
+    )
+    return tracer
+
+
+def test_generate_span_and_trace_id(monkeypatch: pytest.MonkeyPatch, fake_tracer: FakeTracer) -> None:
+    class DummyInstrumentor:
+        @staticmethod
+        def instrument_app(app: Any) -> None:
+            app.instrumented = True
+
+    monkeypatch.setattr(tracing, "FastAPIInstrumentor", DummyInstrumentor)
+
+    class BoomPipeline:
+        def run(self, _: str) -> str:  # pragma: no cover - simple stub
+            raise ValueError("boom")
+
+    app = create_app()
+    app.dependency_overrides[get_fact_pipeline] = lambda: BoomPipeline()
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/generate",
+        json={"text": "boom"},
+        headers={"x-api-key": "change-me"},
+    )
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["trace_id"] == fake_tracer.spans[0].trace_id
+
+    span = fake_tracer.spans[0]
+    assert span.name == "api.generate"
+    assert span.attributes["generate.outcome"] == "error"
+    assert any(isinstance(exc, ValueError) for exc in span.exceptions)
+
+
+@pytest.mark.asyncio()
+async def test_stream_span_records_chunks(fake_tracer: FakeTracer) -> None:
+    class DummyPipeline:
+        def run(self, text: str) -> str:
+            return text
+
+    class DummyState:
+        request_id = "stream-req"
+
+    class DummyRequest:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+            self.state = DummyState()
+
+        async def is_disconnected(self) -> bool:
+            return False
+
+    req = ScoreReq(text="alpha beta gamma delta")
+    request = DummyRequest()
+
+    response = await _sse_stream(
+        req,
+        request,
+        DummyPipeline(),
+        token_delay=0.0,
+        chunk_size=6,
+        cursor=None,
+    )
+
+    async for _ in response.body_iterator:
+        pass
+
+    stream_spans = [span for span in fake_tracer.spans if span.name == "api.stream"]
+    assert stream_spans, "stream span was not recorded"
+    stream_span = stream_spans[0]
+    assert stream_span.attributes["stream.outcome"] == "success"
+    assert stream_span.attributes["stream.chunks_sent"] >= 1
+    assert any(event[0] == "stream.chunk" for event in stream_span.events)
+
+
+@pytest.mark.asyncio()
+async def test_callback_span_records_attempts(monkeypatch: pytest.MonkeyPatch, fake_tracer: FakeTracer) -> None:
+    responses = [
+        type("Resp", (), {"status_code": 500})(),
+        type("Resp", (), {"status_code": 200})(),
+    ]
+
+    class DummyClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - stub
+            pass
+
+        async def __aenter__(self) -> "DummyClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def post(self, url: str, json: Any) -> Any:
+            _ = url, json
+            return responses.pop(0)
+
+    monkeypatch.setattr("factsynth_ultimate.api.routers.httpx.AsyncClient", DummyClient)
+
+    await _post_callback("https://example.com", {"ok": True}, request_id="callback-1")
+
+    callback_spans = [span for span in fake_tracer.spans if span.name == "callback.post"]
+    assert callback_spans, "callback span was not recorded"
+    span = callback_spans[0]
+    assert span.attributes["callback.status"] == "success"
+    assert span.attributes["callback.attempts_used"] == 2
+    assert any(event[0] == "callback.attempt" for event in span.events)


### PR DESCRIPTION
## Summary
- add optional OpenTelemetry exporter configuration helpers and tracing utilities
- instrument generate, streaming, and callback paths with manual spans and expose trace IDs in problem responses
- document tracing setup and add span smoke tests for generate, stream, and callback flows

## Testing
- pytest --no-cov tests/test_tracing.py tests/test_tracing_spans.py


------
https://chatgpt.com/codex/tasks/task_e_68c96af14b2c832986099100edba26f2