### PR TITLE
ci: trigger container release after semantic-release

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -1,6 +1,17 @@
 name: Container Release
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to tag the image with (without the leading v)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version to tag the image with (without the leading v)'
+        required: false
+        type: string
   push:
     branches: [ main ]
     paths:
@@ -14,6 +25,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  id-token: write
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -23,6 +35,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - name: Determine release version
+        id: release_version
+        run: |
+          version="$(jq -r '.inputs.version // ""' "$GITHUB_EVENT_PATH")"
+          echo "RELEASE_VERSION=$version" >>"$GITHUB_ENV"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
@@ -39,12 +57,32 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=sha
+            type=semver,pattern={{version}},value=${{ steps.release_version.outputs.version }},enable=${{ steps.release_version.outputs.version != '' }}
+      - name: Export image reference
+        run: echo "IMAGE_REF=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >>"$GITHUB_ENV"
       - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
+        id: build
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ (steps.meta.outputs.version != '' && format('{0}:v{1}', env.IMAGE_REF, steps.meta.outputs.version)) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20
+      - uses: anchore/sbom-action/download-syft@e8d2a6937ecead383dfe75190d104edd1f9c5751
+      - name: Generate SBOM (SPDX JSON)
+        run: syft ${{ env.IMAGE_REF }}@${{ steps.build.outputs.digest }} -o spdx-json --file sbom.spdx.json
+      - name: Sign container image
+        env:
+          COSIGN_YES: 'true'
+          COSIGN_EXPERIMENTAL: '1'
+        run: cosign sign ${{ env.IMAGE_REF }}@${{ steps.build.outputs.digest }}
+      - name: Attach SBOM attestation
+        env:
+          COSIGN_YES: 'true'
+          COSIGN_EXPERIMENTAL: '1'
+        run: cosign attest --predicate sbom.spdx.json --type spdx ${{ env.IMAGE_REF }}@${{ steps.build.outputs.digest }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,48 @@
+name: Semantic Release
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+  id-token: write
+
+concurrency:
+  group: semantic-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.release.outputs.new_release_published }}
+      version: ${{ steps.release.outputs.new_release_version }}
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 'lts/*'
+      - name: Semantic Release
+        id: release
+        uses: cycjimmy/semantic-release-action@61680d0e9b02ff86f5648ade99e01be17f0260a4
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  container-release:
+    needs: semantic-release
+    if: needs.semantic-release.outputs.published == 'true'
+    uses: ./.github/workflows/container-release.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.semantic-release.outputs.version }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,20 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/github",
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"]
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
## Summary
- add a semantic-release workflow that dispatches the container pipeline with the new version
- enhance the container release workflow to accept version inputs, publish v-prefixed tags, and attach cosign signatures plus SBOM attestations

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c9b0f69d78832983a2e0f2194fe680