### PR TITLE
Add Spectral linting to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,34 @@ on:
 permissions: { contents: read }
 concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }
 jobs:
+  spectral-lint:
+    name: Spectral Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Spectral lint
+        run: |
+          mkdir -p artifacts
+          npm install --global @stoplight/spectral-cli
+          npx spectral lint openapi/openapi.yaml --format sarif --output artifacts/spectral-report.sarif
+
+      - name: Upload Spectral report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: spectral-report
+          path: artifacts/spectral-report.sarif
+          if-no-files-found: ignore
+
   build-test:
+    needs: spectral-lint
     runs-on: ubuntu-latest
     timeout-minutes: 25
     services:


### PR DESCRIPTION
## Summary
- add a dedicated Spectral lint job to the CI workflow
- install @stoplight/spectral-cli and run npx spectral lint against openapi/openapi.yaml
- upload the Spectral SARIF report as an artifact for review and gate the rest of CI on the lint results

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cbf3156314832989af332827791d16